### PR TITLE
Create gbsplay.desktop

### DIFF
--- a/gbsplay.desktop
+++ b/gbsplay.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=gbsplay
+Comment=Gameboy sound player
+Exec=gbsplay %f
+Icon=gbsplay
+Terminal=true
+Type=Application
+Categories=AudioVideo;AudioVideoEditing
+Keywords=gameboy;
+MimeTypes=audio/gbs;


### PR DESCRIPTION
allows associationg gbs files in nautilus/files with gbs extension and playing them in terminal. it would be nice to have an icon for the desktop file. installation should go into /usr/share/applications/ (icon goes to /usr/share/icons/)