### PR TITLE
add alternative MIDI output plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,9 @@ endif
 ifeq ($(plugout_midi),yes)
 objs_gbsplay += plugout_midi.o
 endif
+ifeq ($(plugout_altmidi),yes)
+objs_gbsplay += plugout_altmidi.o
+endif
 ifeq ($(plugout_pulse),yes)
 objs_gbsplay += plugout_pulse.o
 GBSPLAYLDFLAGS += -lpulse-simple -lpulse

--- a/configure
+++ b/configure
@@ -546,6 +546,7 @@ Output Plugins:
   --disable-dsound       omit Direct Sound output plugin
   --disable-iodumper     omit iodumper plugin
   --disable-midi         omit MIDI file writer plugin
+  --disable-altmidi      omit alternative MIDI file writer plugin
   --disable-nas          omit NAS sound output plugin
   --disable-pulse        omit PulseAudio sound output plugin
   --disable-stdout       omit stdout file writer plugin
@@ -565,6 +566,7 @@ OPTS="${OPTS} use_hardening"
 OPTS="${OPTS} use_i18n"
 OPTS="${OPTS} use_iodumper"
 OPTS="${OPTS} use_midi"
+OPTS="${OPTS} use_altmidi"
 OPTS="${OPTS} use_nas"
 OPTS="${OPTS} use_pulse"
 OPTS="${OPTS} use_regparm"
@@ -943,6 +945,7 @@ setdefault use_sharedlibgbs no
 setdefault use_debug no
 
 setdefault use_midi yes
+setdefault use_altmidi yes
 setdefault use_stdout yes
 setdefault use_iodumper yes
 
@@ -1005,6 +1008,7 @@ __EOF__
     echo plugout_dsound := $use_dsound
     echo plugout_iodumper := $use_iodumper
     echo plugout_midi := $use_midi
+    echo plugout_altmidi := $use_altmidi
     echo plugout_nas := $use_nas
     echo plugout_pulse := $use_pulse
     echo plugout_stdout := $use_stdout
@@ -1021,6 +1025,7 @@ __EOF__
     plugout_x DSOUND
     plugout_x IODUMPER
     plugout_x MIDI
+    plugout_x ALTMIDI
     plugout_x NAS
     plugout_x PULSE
     plugout_x STDOUT

--- a/gbhw.c
+++ b/gbhw.c
@@ -1,8 +1,8 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2006,2008 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
- *                       Christian Garbs <mitch@cgarbs.de>
+ * 2003-2006,2008,2018 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ *                            Christian Garbs <mitch@cgarbs.de>
  * Licensed under GNU GPL.
  */
 
@@ -99,6 +99,9 @@ static /*@null@*/ /*@only@*/ struct gbhw_buffer *impbuf = NULL;   /* internal im
 
 static gbhw_iocallback_fn iocallback;
 static /*@null@*/ /*@dependent@*/ void *iocallback_priv;
+
+static gbhw_stepcallback_fn stepcallback;
+static /*@null@*/ /*@dependent@*/ void *stepcallback_priv;
 
 #define TAP1_15		0x4000;
 #define TAP2_15		0x2000;
@@ -839,6 +842,12 @@ regparm void gbhw_setiocallback(gbhw_iocallback_fn fn, void *priv)
 	iocallback_priv = priv;
 }
 
+regparm void gbhw_setstepcallback(gbhw_stepcallback_fn fn, void *priv)
+{
+	stepcallback = fn;
+	stepcallback_priv = priv;
+}
+
 static regparm void gbhw_impbuf_reset(struct gbhw_buffer *impbuf)
 {
 	assert(sound_div_tc != 0);
@@ -1076,6 +1085,8 @@ regparm long gbhw_step(long time_to_work)
 			cycles += step;
 			sum_cycles += step;
 			gb_sound(step);
+			if (stepcallback)
+			   stepcallback(sum_cycles, gbhw_ch, stepcallback_priv);
 		}
 
 		if (vblankctr > 0) vblankctr -= cycles;

--- a/gbhw.h
+++ b/gbhw.h
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2005 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2003-2005,2018 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  * Licensed under GNU GPL.
  */
 
@@ -63,9 +63,11 @@ extern struct gbhw_channel gbhw_ch[4];
 
 typedef regparm void (*gbhw_callback_fn)(/*@temp@*/ struct gbhw_buffer *buf, /*@temp@*/ void *priv);
 typedef regparm void (*gbhw_iocallback_fn)(long cycles, uint32_t addr, uint8_t valu, /*@temp@*/ void *priv);
+typedef regparm void (*gbhw_stepcallback_fn)(const long cycles, const struct gbhw_channel[], /*@temp@*/ void *priv);
 
 regparm void gbhw_setcallback(/*@dependent@*/ gbhw_callback_fn fn, /*@dependent@*/ void *priv);
 regparm void gbhw_setiocallback(/*@dependent@*/ gbhw_iocallback_fn fn, /*@dependent@*/ void *priv);
+regparm void gbhw_setstepcallback(/*@dependent@*/ gbhw_stepcallback_fn fn, /*@dependent@*/ void *priv);
 regparm long gbhw_setfilter(const char *type);
 regparm void gbhw_setrate(long rate);
 regparm void gbhw_setbuffer(/*@dependent@*/ struct gbhw_buffer *buffer);

--- a/gbsplay.c
+++ b/gbsplay.c
@@ -1,8 +1,8 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2005,2008 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
- *                       Christian Garbs <mitch@cgarbs.de>
+ * 2003-2005,2008,2018 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ *                            Christian Garbs <mitch@cgarbs.de>
  * Licensed under GNU GPL.
  */
 
@@ -82,6 +82,7 @@ static plugout_open_fn  sound_open;
 static plugout_skip_fn  sound_skip;
 static plugout_pause_fn sound_pause;
 static plugout_io_fn    sound_io;
+static plugout_step_fn  sound_step;
 static plugout_write_fn sound_write;
 static plugout_close_fn sound_close;
 
@@ -189,6 +190,11 @@ static regparm void swap_endian(struct gbhw_buffer *buf)
 static regparm void iocallback(long cycles, uint32_t addr, uint8_t val, void *priv)
 {
 	sound_io(cycles, addr, val);
+}
+
+static regparm void stepcallback(long cycles, const struct gbhw_channel chan[], void *priv)
+{
+	sound_step(cycles, chan);
 }
 
 static regparm void callback(struct gbhw_buffer *buf, void *priv)
@@ -667,6 +673,7 @@ static regparm void select_plugin(void)
 	sound_open = plugout->open;
 	sound_skip = plugout->skip;
 	sound_io = plugout->io;
+	sound_step = plugout->step;
 	sound_write = plugout->write;
 	sound_close = plugout->close;
 	sound_pause = plugout->pause;
@@ -712,6 +719,8 @@ int main(int argc, char **argv)
 
 	if (sound_io)
 		gbhw_setiocallback(iocallback, NULL);
+	if (sound_step)
+		gbhw_setstepcallback(stepcallback, NULL);
 	if (sound_write)
 		gbhw_setcallback(callback, NULL);
 	gbhw_setrate(rate);

--- a/libgbs_whitelist.txt
+++ b/libgbs_whitelist.txt
@@ -7,6 +7,7 @@ gbhw_pause
 gbhw_setbuffer
 gbhw_setcallback
 gbhw_setiocallback
+gbhw_setstepcallback
 gbhw_setfilter
 gbhw_setrate
 gbhw_io_peek

--- a/man/gbsplay.in.1
+++ b/man/gbsplay.in.1
@@ -165,6 +165,14 @@ see `\fIgbsplay\ -o\ list\fP'.
 .B alsa
 Use the ALSA sound driver for sound output.
 .TP
+.B altmidi
+Alternative implementation of the MIDI output plugin
+(see \fImidi\fP below).
+Should export more accurate note off events
+(the length register is taken into account),
+but generated MIDI files will be more complicated and fine grained
+and probably not suitable for editing or printing a score.
+.TP
 .B devdsp
 Use the OSS sound driver for sound output via \fI/dev/dsp\fP.
 .TP

--- a/plugout.c
+++ b/plugout.c
@@ -1,8 +1,8 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2005,2013 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
- *                       Christian Garbs <mitch@cgarbs.de>
+ * 2003-2005,2013,2018 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ *                            Christian Garbs <mitch@cgarbs.de>
  * Licensed under GNU GPL.
  */
 
@@ -28,6 +28,9 @@ extern const struct output_plugin plugout_iodumper;
 #endif
 #ifdef PLUGOUT_MIDI
 extern const struct output_plugin plugout_midi;
+#endif
+#ifdef PLUGOUT_ALTMIDI
+extern const struct output_plugin plugout_altmidi;
 #endif
 #ifdef PLUGOUT_NAS
 extern const struct output_plugin plugout_nas;
@@ -63,6 +66,9 @@ static output_plugin_const_t plugouts[] = {
 #endif
 #ifdef PLUGOUT_MIDI
 	&plugout_midi,
+#endif
+#ifdef PLUGOUT_ALTMIDI
+	&plugout_altmidi,
 #endif
 #ifdef PLUGOUT_IODUMPER
 	&plugout_iodumper,

--- a/plugout.h
+++ b/plugout.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 #include "config.h"
+#include "gbhw.h"
 
 #if PLUGOUT_DSOUND == 1
 #  define PLUGOUT_DEFAULT "dsound"
@@ -25,6 +26,7 @@ typedef long    regparm (*plugout_open_fn )(enum plugout_endian endian, long rat
 typedef int     regparm (*plugout_skip_fn )(int subsong);
 typedef void    regparm (*plugout_pause_fn)(int pause);
 typedef int     regparm (*plugout_io_fn   )(long cycles, uint32_t addr, uint8_t val);
+typedef int     regparm (*plugout_step_fn )(const long cycles, const struct gbhw_channel[]);
 typedef ssize_t regparm (*plugout_write_fn)(const void *buf, size_t count);
 typedef void    regparm (*plugout_close_fn)(void);
 
@@ -38,6 +40,7 @@ struct output_plugin {
 	plugout_skip_fn  skip;
 	plugout_pause_fn pause;
 	plugout_io_fn    io;
+	plugout_step_fn  step;
 	plugout_write_fn write;
 	plugout_close_fn close;
 };

--- a/plugout_altmidi.c
+++ b/plugout_altmidi.c
@@ -1,0 +1,374 @@
+/*
+ * gbsplay is a Gameboy sound player
+ *
+ * 2006 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ *
+ * alternative MIDI output plugin
+ *
+ * 2018 (C) by Christian Garbs <mitch@cgarbs.de>
+ *
+ * based on the MIDI output plugin
+
+ * 2008 (C) by Vegard Nossum
+ *
+ * Licensed under GNU GPL.
+ */
+
+#include "common.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "plugout.h"
+#include "gbhw.h"
+
+#define FILENAMESIZE 32
+#define LN2 .69314718055994530941
+#define MAGIC 5.78135971352465960412
+#define FREQ(x) (262144 / (x))
+#define NOTE(x) ((long)((log(FREQ(x))/LN2 - MAGIC)*12 + .2))
+
+static long regparm midi_open(enum plugout_endian endian, long rate)
+{
+	return 0;
+}
+
+static FILE *file = NULL;
+
+static long track_length;
+static long track_length_offset;
+
+static long cycles_prev = 0;
+
+static int note[4] = {0, 0, 0, 0};
+static int volume[4] = {0, 0, 0, 0};
+static int playing[4] = {0, 0, 0, 0};
+
+static int midi_write_u32(uint32_t x)
+{
+	uint8_t s[4];
+
+	s[0] = x >> 24;
+	s[1] = x >> 16;
+	s[2] = x >> 8;
+	s[3] = x;
+
+	if (fwrite(s, 1, 4, file) != 4)
+		return 1;
+	return 0;
+}
+
+static int midi_write_u16(uint16_t x)
+{
+	uint8_t s[2];
+
+	s[0] = x >> 8;
+	s[1] = x;
+
+	if (fwrite(s, 1, 2, file) != 2)
+		return 1;
+	return 0;
+}
+
+static int midi_write_varlen(unsigned long x)
+{
+	uint8_t data[4];
+	unsigned int i;
+
+	for (i = 0; i < 4; ++i) {
+		data[3 - i] = (x & 0x7f) | 0x80;
+		x >>= 7;
+
+		if (!x) {
+			++i;
+			break;
+		}
+	}
+
+	data[3] &= ~0x80;
+	if (fwrite(data + 4 - i, 1, i, file) != i)
+		return 1;
+
+	track_length += i;
+	return 0;
+}
+
+static int midi_write_event(long cycles, const uint8_t *s, unsigned int n)
+{
+	if (midi_write_varlen((cycles - cycles_prev) >> 14))
+		return 1;
+
+	if (fwrite(s, 1, n, file) != n)
+		return 1;
+
+	track_length += n;
+
+	cycles_prev = cycles;
+	return 0;
+}
+
+static int midi_open_track(int subsong)
+{
+	char *filename;
+	if ((filename = malloc(FILENAMESIZE)) == NULL)
+		goto out;
+	
+	if (snprintf(filename, FILENAMESIZE, "gbsplay-%d.mid", subsong + 1) >= FILENAMESIZE)
+		goto out;
+
+	file = fopen(filename, "wb");
+	if (!file) {
+		free(filename);
+		goto out;
+	}
+
+	free(filename);
+
+	/* Header type */
+	if (fwrite("MThd", 1, 4, file) != 4)
+		goto out_file;
+
+	/* Header length */
+	if (midi_write_u32(6))
+		goto out_file;
+
+	/* Format */
+	if (midi_write_u16(0))
+		goto out_file;
+
+	/* Tracks */
+	if (midi_write_u16(1))
+		goto out_file;
+
+	/* Division */
+	/* XXX: Do some real calculation instead of this magic number :-) */
+	if (midi_write_u16(124))
+		goto out_file;
+
+	/* Track type */
+	if (fwrite("MTrk", 1, 4, file) != 4)
+		goto out_file;
+
+	/* Track length (placeholder) */
+	track_length = 0;
+	track_length_offset = ftell(file);
+	if (track_length_offset == -1)
+		goto out_file;
+
+	if (midi_write_u32(0))
+		goto out_file;
+
+	return 0;
+
+out_file:
+	fclose(file);
+	file = NULL;
+out:
+	return 1;
+}
+
+static int midi_close_track()
+{
+	uint8_t event[3];
+
+	/* End of track */
+	event[0] = 0xff;
+	event[1] = 0x2f;
+	event[2] = 0x00;
+
+	if (midi_write_event(cycles_prev, event, 3))
+		goto out;
+
+	if (fseek(file, track_length_offset, SEEK_SET) == -1)
+		goto out;
+
+	if (midi_write_u32(track_length))
+		goto out;
+
+	fclose(file);
+	file = NULL;
+	return 0;
+
+out:
+	file = NULL;
+	return 1;
+}
+
+static int regparm midi_skip(int subsong)
+{
+	cycles_prev = 0;
+
+	if (file) {
+		if (midi_close_track())
+			return 1;
+	}
+
+	return midi_open_track(subsong);
+}
+
+static int note_on(long cycles, int channel, int new_note)
+{
+	uint8_t event[3];
+
+	event[0] = 0x90 | channel;
+	event[1] = new_note;
+	event[2] = volume[channel];
+
+	if (midi_write_event(cycles, event, 3))
+		return 1;
+
+	note[channel] = new_note;
+
+	return 0;
+}
+
+static int note_off(long cycles, int channel)
+{
+	uint8_t event[3];
+
+	if (!note[channel])
+		return 0;
+
+	event[0] = 0x80 | channel;
+	event[1] = note[channel];
+	event[2] = 0;
+
+	if (midi_write_event(cycles, event, 3))
+		return 1;
+
+	note[channel] = 0;
+	
+	return 0;
+}
+
+static int pan(long cycles, int channel, int pan)
+{
+	uint8_t event[3];
+
+	event[0] = 0xb0 | channel;
+	event[1] = 0x0a;
+	event[2] = pan;
+
+	if (midi_write_event(cycles, event, 3))
+		return 1;
+
+	return 0;
+}
+
+static int regparm midi_step(long cycles, const struct gbhw_channel chan[])
+{
+	int c;
+	int new_playing;
+	int new_note;
+	const struct gbhw_channel *ch;
+
+	for (c = 0; c < 3; c++) {
+		ch = &chan[c];
+		new_playing = ch->running && ch->master && ch->volume;
+
+		if (playing[c]) {
+			if (new_playing) {
+				new_note = NOTE(ch->div_tc) + 21;
+				if (new_note != note[c]) {
+					if (note_off(cycles, c))
+						return 1;
+					if (new_note < 0 || new_note >= 0x80)
+						continue;
+					if (note_on(cycles, c, new_note))
+						return 1;
+				}
+			} else {
+				if (note_off(cycles, c))
+					return 1;
+				playing[c] = 0;
+			}
+		} else {
+			if (new_playing) {
+				new_note = NOTE(ch->div_tc) + 21;
+				if (new_note < 0 || new_note >= 0x80)
+					continue;
+				if (note_on(cycles, c, new_note))
+					return 1;
+				playing[c] = 1;
+			}
+		}
+		
+	}
+	
+	return 0;
+}
+
+static int regparm midi_io(long cycles, uint32_t addr, uint8_t val)
+{
+	long chan = (addr - 0xff10) / 5;
+
+	if (!file)
+		return 1;
+
+	switch (addr) {
+	case 0xff12:
+	case 0xff17:
+		volume[chan] = 8 * (val >> 4);
+		break;
+		
+	case 0xff14:
+	case 0xff19:
+	case 0xff1e:
+		/* Channel start trigger */
+		if ((val & 0x80) == 0x80) {
+			if (note_off(cycles, chan))
+				return 1;
+			playing[chan] = 0;
+		}
+		break;
+
+	case 0xff1c:
+		volume[2] = 32 * ((4 - (val >> 5)) & 3);
+		break;
+		
+	case 0xff25:
+		for (chan = 0; chan < 4; chan++)
+			switch ((val >> chan) & 0x11) {
+			case 0x10:
+				pan(cycles, chan, 0);
+				break;
+			case 0x01:
+				pan(cycles, chan, 127);
+				break;
+			default:
+				pan(cycles, chan, 64);
+			}
+		break;
+		
+	}
+
+	return 0;
+}
+
+static void regparm midi_close(void)
+{
+	int chan;
+	
+	if (!file)
+		return;
+
+	for (chan = 0; chan < 4; chan++)
+		if (note_off(cycles_prev + 1, chan))
+			return;
+	
+	midi_close_track();
+}
+
+const struct output_plugin plugout_altmidi = {
+	.name = "altmidi",
+	.description = "alternative MIDI file writer",
+	.open = midi_open,
+	.skip = midi_skip,
+	.io = midi_io,
+	.step = midi_step,
+	.close = midi_close,
+};


### PR DESCRIPTION
While I was recently tinkering on ``plugout_midi.c``, I realised that the MIDI output does not take the length registers into account and short notes will not be ended at the proper time. I tried to take the length into account but realised that it will only work properly if the MIDI export does cycle-accurate processing of the length register – but that's impossible with the IO-based callbacks.

Fortunately we already have something that does cycle-accurate bookkeeping of the length register (as well as all other registers): gbsplay itself :-)  This realization lead to the idea for another MIDI output plugin.

``plugout_midi.c`` registers as an IO callback and basically duplicates part of ``gbhw.c`` to keep track of what is going on.  Some bookkeeping is needed and that state is basically a more or less accurate duplication of the state in ``gbhw.c``. Things that happen between two IO calls (eg. a length register running out, ending a note) are not seen by ``plugout_midi.c``.

``plugout_altmidi.c`` instead registers a new callback into every Gameboy cpu cycle and directly parses the ``gbhw_channel`` state from ``gbhw.c``.  It is nearly cycle accurate (and thus more CPU intensive) and can take the length registers into account.  Duplicate bookkeeping of the sound hardware state and duplicate code to handle the IO calls are greatly reduced.  Currently only two IOs are registerd in the IO callback:
* Channel triggers are hard to deduce from the sound hardware state, so the IO calls are used to stop the current note. Restarting the note happens in the default code path in the new per-step callback.
* Pan effects (left/right channel enable IOs) can be mapped straight to MIDI, so it is done via IO callback. This could also be done in the per-step callback, but this would mean a (mostly unneded) comparison operation every step with no benefits.

#### current status
I did listening tests via ``timidity -E i80 -int gbsfile-%d.mid`` and it seems to work quite good. Even drymouth sounds kind of like it should ;-)

#### todo
* I don't know if the new step-callback is the way to go. That's quite a lot of internal state that is opened up to plugins. Any ideas?
