### PR TITLE
Fixing bug in sed regular expression:

### DIFF
--- a/contrib/gbs2ogg.sh
+++ b/contrib/gbs2ogg.sh
@@ -28,7 +28,7 @@ FILEBASE=`echo "$FILEBASE"|sed 's/.gbs$//'`
 
 # get subsong count
 # get song info
-    gbsinfo "$FILENAME" | cut -c 17- | sed -e 's/^"//' -e 's/"$//' | (
+    gbsinfo "$FILENAME" | cut -c 17- | sed -e 's/"//' -e 's/"$//' | (
     read GBSVERSION
     read TITLE
     read AUTHOR


### PR DESCRIPTION
**Bug fix**. Regular expressions does not remove the leading quotation-mark `"` in strings

This bug causes strings containing spaces to be incorrectly parsed by `sed`

For example:
> "1995 Capcom"

gets parsed as:

> "1995 Capcom

As a result the tags in the ogg-files become messed up as well.

This is the output produced with the current version:
```
$ ogginfo DMG-ASFJ-JPN-01.ogg -v
Processing file "DMG-ASFJ-JPN-01.ogg"...

New logical stream (#1, serial: 21af413a): type vorbis
Vorbis headers parsed for stream 1, information follows...
Version: 0
Vendor: Xiph.Org libVorbis I 20150105 (⛄⛄⛄⛄)
Channels: 2
Rate: 44100

Nominal bitrate: 192,000000 kb/s
Upper bitrate not set
Lower bitrate not set
User comments section follows...
	copyright="1995 Capcom
	COMMENT=Subsong 1
	title="Street Fighter II
	artist="Norihiko Togashi
	genre=Gameboy music
	tracknumber=1
Vorbis stream 1:
	Total data length: 67363 bytes
	Playback length: 0m:05.061s
	Average bitrate: 106,461737 kb/s
Logical stream 1 ended

```

After changing 1 character in the regular expression I now get this:
```
$ ogginfo DMG-ASFJ-JPN-01.ogg -v
Processing file "DMG-ASFJ-JPN-01.ogg"...

User comments section follows...
	copyright=1995 Capcom
	COMMENT=Subsong 1
	title=Street Fighter II
	artist=Norihiko Togashi
	genre=Gameboy music
	tracknumber=1
```
