### PR TITLE
add SDL2 plugout

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        sudo apt-get install libasound2-dev libpulse-dev libaudio-dev libx11-dev
+        sudo apt-get install libasound2-dev libpulse-dev libaudio-dev libx11-dev libsdl2-dev
     - name: Build and test
       env:
         CC: ${{ matrix.compiler }}
@@ -33,7 +33,7 @@ jobs:
         make
     - name: Check activated plugouts
       run: |
-        ./check_plugouts.sh alsa pulse devdsp nas
+        ./check_plugouts.sh alsa pulse devdsp nas sdl
     - name: Check build flags
       run: |
         ./check_buildflags.sh ${{ matrix.flags }}

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -22,6 +22,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        brew install sdl2
     - name: Build and test
       env:
         CC: ${{ matrix.compiler }}
@@ -30,7 +33,7 @@ jobs:
         make
     - name: Check activated plugouts
       run: |
-        ./check_plugouts.sh
+        ./check_plugouts.sh sdl
     - name: Check build flags
       run: |
         ./check_buildflags.sh ${{ matrix.flags }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -24,11 +24,11 @@ jobs:
             packages: gcc
             plugouts: dsound devdsp
           - msystem: MINGW64
-            packages: mingw-w64-x86_64-toolchain
-            plugouts: dsound
+            packages: mingw-w64-x86_64-toolchain mingw-w64-x86_64-SDL2
+            plugouts: dsound sdl
           - msystem: MINGW32
-            packages: mingw-w64-i686-toolchain
-            plugouts: dsound
+            packages: mingw-w64-i686-toolchain mingw-w64-i686-SDL2
+            plugouts: dsound sdl
 
     defaults:
       run:

--- a/HISTORY
+++ b/HISTORY
@@ -26,12 +26,13 @@ Removals:
 Enhancements:
 
 - gbsplay:
+  - add SDL2 plugout
   - transparent decompression of gzip-compressed files
   - basic VGM file support
   - remove unneeded dsound3d dependency from dsound plugin
 
 - xgbsplay:
-  - added simple X11 frontend; use configure --with-xgbsplay
+  - add simple X11 frontend; use configure --with-xgbsplay
 
 - build process:
   - depend on bash 3.x for configure script

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,12 @@ objs_xgbsplay += plugout_nas.o
 GBSPLAYLDFLAGS += -laudio $(libaudio_flags)
 XGBSPLAYLDFLAGS += -laudio $(libaudio_flags)
 endif
+ifeq ($(plugout_sdl),yes)
+objs_gbsplay += plugout_sdl.o
+objs_xgbsplay += plugout_sdl.o
+GBSPLAYLDFLAGS += -lSDL2
+XGBSPLAYLDFLAGS += -lSDL2
+endif
 ifeq ($(plugout_stdout),yes)
 objs_gbsplay += plugout_stdout.o
 objs_xgbsplay += plugout_stdout.o

--- a/configure
+++ b/configure
@@ -4,7 +4,7 @@
 #
 # generate config.mk for gbsplay Makefile
 #
-# 2003-2006,2008,2010,2015,2017-2019 (C) by Christian Garbs <mitch@cgarbs.de>
+# 2003-2006,2008,2010,2015,2017-2020 (C) by Christian Garbs <mitch@cgarbs.de>
 #                                           Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
 # Licensed under GNU GPL v1 or, at your option, any later version.
 #
@@ -532,6 +532,7 @@ Output Plugins:
   --disable-altmidi      omit alternative MIDI file writer plugin
   --disable-nas          omit NAS sound output plugin
   --disable-pulse        omit PulseAudio sound output plugin
+  --disable-sdl          omit SDL sound output plugin
   --disable-stdout       omit stdout file writer plugin
 EOF
     exit "$1"
@@ -553,6 +554,7 @@ OPTS="${OPTS} use_midi"
 OPTS="${OPTS} use_altmidi"
 OPTS="${OPTS} use_nas"
 OPTS="${OPTS} use_pulse"
+OPTS="${OPTS} use_sdl"
 OPTS="${OPTS} use_sharedlibgbs"
 OPTS="${OPTS} use_stdout"
 OPTS="${OPTS} use_zlib"
@@ -791,6 +793,13 @@ EOF
         use_nas=yes
     fi
     recheck_use nas
+fi
+
+if [ "$use_sdl" != no ]; then
+    remember_use sdl
+    check_include SDL2/SDL.h
+    use_sdl="$have_SDL2_SDL_h"
+    recheck_use sdl
 fi
 
 if [ "$use_i18n" != no ]; then
@@ -1098,6 +1107,7 @@ __EOF__
     echo plugout_altmidi := $use_altmidi
     echo plugout_nas := $use_nas
     echo plugout_pulse := $use_pulse
+    echo plugout_sdl := $use_sdl
     echo plugout_stdout := $use_stdout
     echo configured := yes
 ) > config.mk
@@ -1117,6 +1127,7 @@ __EOF__
     plugout_x NAS
     plugout_x PULSE
     plugout_x STDOUT
+    plugout_x SDL
     use_x I18N
     use_x ZLIB
     have_x ESTRPIPE

--- a/configure
+++ b/configure
@@ -797,7 +797,7 @@ fi
 
 if [ "$use_sdl" != no ]; then
     remember_use sdl
-    check_include SDL2/SDL.h
+    check_include SDL2/SDL.h "" "#define SDL_MAIN_HANDLED"
     use_sdl="$have_SDL2_SDL_h"
     recheck_use sdl
 fi

--- a/man/gbsplay.in.1
+++ b/man/gbsplay.in.1
@@ -208,6 +208,11 @@ Use the Pulseaudio sound driver for sound output.
 .TP
 .B sdl
 Use SDL sound driver for sound output.
+On Microsoft Windows, libSDL might use the \fIwasapi\fP audio backend
+by default which can result in choppy sound.  To fix this, set the
+environment variable \fISDL_AUDIODRIVER\fP to \fIdirectsound\fP to
+select a different libSDL audio backend (or switch to the \fIdsound\fP
+plugout instead).
 .TP
 .B stdout
 Dump the raw audio stream to stdout.

--- a/man/gbsplay.in.1
+++ b/man/gbsplay.in.1
@@ -206,6 +206,9 @@ Use the NAS sound driver for sound output to a Network Audio Server.
 .B pulse
 Use the Pulseaudio sound driver for sound output.
 .TP
+.B sdl
+Use SDL sound driver for sound output.
+.TP
 .B stdout
 Dump the raw audio stream to stdout.
 This reduces the verbosity to 0 (see \fI-q\fP)

--- a/man/xgbsplay.in.1
+++ b/man/xgbsplay.in.1
@@ -177,6 +177,9 @@ Use the NAS sound driver for sound output to a Network Audio Server.
 .B pulse
 Use the Pulseaudio sound driver for sound output.
 .TP
+.B sdl
+Use SDL sound driver for sound output.
+.TP
 .B stdout
 Dump the raw audio stream to stdout.
 This reduces the verbosity to 0 (see \fI-q\fP)

--- a/man/xgbsplay.in.1
+++ b/man/xgbsplay.in.1
@@ -179,6 +179,11 @@ Use the Pulseaudio sound driver for sound output.
 .TP
 .B sdl
 Use SDL sound driver for sound output.
+On Microsoft Windows, libSDL might use the \fIwasapi\fP audio backend
+by default which can result in choppy sound.  To fix this, set the
+environment variable \fISDL_AUDIODRIVER\fP to \fIdirectsound\fP to
+select a different libSDL audio backend (or switch to the \fIdsound\fP
+plugout instead).
 .TP
 .B stdout
 Dump the raw audio stream to stdout.

--- a/plugout.c
+++ b/plugout.c
@@ -38,6 +38,9 @@ extern const struct output_plugin plugout_nas;
 #ifdef PLUGOUT_PULSE
 extern const struct output_plugin plugout_pulse;
 #endif
+#ifdef PLUGOUT_SDL
+extern const struct output_plugin plugout_sdl;
+#endif
 #ifdef PLUGOUT_STDOUT
 extern const struct output_plugin plugout_stdout;
 #endif
@@ -72,6 +75,9 @@ static output_plugin_const_t plugouts[] = {
 #endif
 #ifdef PLUGOUT_IODUMPER
 	&plugout_iodumper,
+#endif
+#ifdef PLUGOUT_SDL
+	&plugout_sdl,
 #endif
 	NULL
 };

--- a/plugout.h
+++ b/plugout.h
@@ -19,6 +19,8 @@
 #  define PLUGOUT_DEFAULT "pulse"
 #elif PLUGOUT_ALSA == 1
 #  define PLUGOUT_DEFAULT "alsa"
+#elif PLUGOUT_SDL == 1
+#  define PLUGOUT_DEFAULT "sdl"
 #else
 #  define PLUGOUT_DEFAULT "oss"
 #endif

--- a/plugout_sdl.c
+++ b/plugout_sdl.c
@@ -1,0 +1,80 @@
+/*
+ * gbsplay is a Gameboy sound player
+ *
+ * 2020 (C) by Christian Garbs <mitch@cgarbs.de>
+ * Licensed under GNU GPL v1 or, at your option, any later version.
+ *
+ * SDL2 sound output plugin
+ */
+
+#include "common.h"
+
+#include <time.h>
+
+#include <SDL2/SDL.h>
+
+#include "plugout.h"
+
+static const int PLAYBACK_MODE = 0;
+static const int NO_CHANGES_ALLOWED = 0;
+static const int UNPAUSE = 0;
+
+static const struct timespec SLEEP_INTERVAL = {
+	.tv_sec = 0,
+	.tv_nsec = 1000
+};
+
+int device;
+
+static long sdl_open(enum plugout_endian endian, long rate)
+{
+	SDL_AudioSpec desired, obtained;
+	
+	if (SDL_Init(SDL_INIT_AUDIO) != 0) {
+		fprintf(stderr, _("Could not init SDL: %s\n"), SDL_GetError());
+		return -1;
+	}
+
+	// TODO: what about endianess?
+	SDL_zero(desired);
+	desired.freq = rate;
+	desired.format = AUDIO_S16;
+	desired.channels = 2;
+	desired.samples = 1024; // 4096;
+	desired.callback = NULL;
+
+	device = SDL_OpenAudioDevice(NULL, PLAYBACK_MODE, &desired, &obtained, NO_CHANGES_ALLOWED);
+	if (device == 0) {
+		fprintf(stderr, _("Could not open SDL audio device: %s\n"), SDL_GetError());
+		return -1;
+	}
+
+	SDL_PauseAudioDevice(device, UNPAUSE);
+
+	return 0;
+}
+
+static ssize_t sdl_write(const void *buf, size_t count)
+{
+	while (SDL_GetQueuedAudioSize(device) > count)
+		nanosleep(&SLEEP_INTERVAL, NULL);
+
+	if (SDL_QueueAudio(device, buf, count) != 0) {
+		fprintf(stderr, _("Could not write SDL audio data: %s\n"), SDL_GetError());
+		return -1;
+	}
+	return count;
+}
+
+static void sdl_close()
+{
+	SDL_Quit();
+}
+
+const struct output_plugin plugout_sdl = {
+	.name = "sdl",
+	.description = "SDL sound driver",
+	.open = sdl_open,
+	.write = sdl_write,
+	.close = sdl_close,
+};

--- a/plugout_sdl.c
+++ b/plugout_sdl.c
@@ -16,7 +16,14 @@
 #include "plugout.h"
 
 static const int PLAYBACK_MODE = 0;
+static const int NO_CHANGES = 0;
 static const int UNPAUSE = 0;
+
+#ifdef SDL_AUDIO_ALLOW_SAMPLES_CHANGE
+	static const int SDL_FLAGS = SDL_AUDIO_ALLOW_SAMPLES_CHANGE;
+#else
+	static const int SDL_FLAGS = NO_CHANGES;
+#endif
 
 static const struct timespec SLEEP_INTERVAL = {
 	.tv_sec = 0,
@@ -42,7 +49,7 @@ static long sdl_open(enum plugout_endian endian, long rate)
 	desired.samples = 1024; // 4096;
 	desired.callback = NULL;
 
-	device = SDL_OpenAudioDevice(NULL, PLAYBACK_MODE, &desired, &obtained, SDL_AUDIO_ALLOW_SAMPLES_CHANGE);
+	device = SDL_OpenAudioDevice(NULL, PLAYBACK_MODE, &desired, &obtained, SDL_FLAGS);
 	if (device == 0) {
 		fprintf(stderr, _("Could not open SDL audio device: %s\n"), SDL_GetError());
 		return -1;

--- a/plugout_sdl.c
+++ b/plugout_sdl.c
@@ -41,13 +41,17 @@ static long sdl_open(enum plugout_endian endian, long rate)
 		return -1;
 	}
 
-	// TODO: what about endianess?
 	SDL_zero(desired);
 	desired.freq = rate;
-	desired.format = AUDIO_S16;
 	desired.channels = 2;
-	desired.samples = 1024; // 4096;
+	desired.samples = 1024;
 	desired.callback = NULL;
+
+	switch (endian) {
+	case PLUGOUT_ENDIAN_BIG:    desired.format = AUDIO_S16MSB; break;
+	case PLUGOUT_ENDIAN_LITTLE: desired.format = AUDIO_S16LSB; break;
+	case PLUGOUT_ENDIAN_NATIVE: desired.format = AUDIO_S16SYS; break;
+	}
 
 	device = SDL_OpenAudioDevice(NULL, PLAYBACK_MODE, &desired, &obtained, SDL_FLAGS);
 	if (device == 0) {

--- a/plugout_sdl.c
+++ b/plugout_sdl.c
@@ -15,14 +15,14 @@
 
 #include "plugout.h"
 
-static const int PLAYBACK_MODE = 0;
-static const int NO_CHANGES = 0;
-static const int UNPAUSE = 0;
+#define PLAYBACK_MODE      0
+#define NO_CHANGES_ALLOWED 0
+#define UNPAUSE            0
 
 #ifdef SDL_AUDIO_ALLOW_SAMPLES_CHANGE
-	static const int SDL_FLAGS = SDL_AUDIO_ALLOW_SAMPLES_CHANGE;
+	#define SDL_FLAGS SDL_AUDIO_ALLOW_SAMPLES_CHANGE
 #else
-	static const int SDL_FLAGS = NO_CHANGES;
+	#define SDL_FLAGS NO_CHANGES_ALLOWED
 #endif
 
 static const struct timespec SLEEP_INTERVAL = {

--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.0.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-27 22:20+0200\n"
-"PO-Revision-Date: 2015-07-18 22:22+0200\n"
+"POT-Creation-Date: 2020-11-12 21:14+0100\n"
+"PO-Revision-Date: 2020-11-12 21:21+0100\n"
 "Last-Translator: Christian Garbs <mitch@cgarbs.de>\n"
 "Language-Team: none\n"
 "Language: de\n"
@@ -95,16 +95,16 @@ msgstr ""
 "\n"
 
 #, c-format
-msgid "Bad GD3 offset: %08x\n"
-msgstr "Unzulässiger GD3 offset: %08x\n"
+msgid "Bad GD3 offset: %08lx\n"
+msgstr "Unzulässiger GD3 offset: %08lx\n"
 
 #, c-format
-msgid "Bad data length: %d\n"
-msgstr "Unzulässige Datenlänge: %d\n"
+msgid "Bad data length: %ld\n"
+msgstr "Unzulässige Datenlänge: %ld\n"
 
 #, c-format
-msgid "Bad file size in header: %d\n"
-msgstr "Unzulässige Dateigröße im Header: %d\n"
+msgid "Bad file size in header: %ld\n"
+msgstr "Unzulässige Dateigröße im Header: %ld\n"
 
 #, c-format
 msgid "Bank @0x4000:     %d\n"
@@ -128,6 +128,10 @@ msgid "Copyright:"
 msgstr "Copyright:"
 
 #, c-format
+msgid "Could not init SDL: %s\n"
+msgstr "Konnte SDL nicht initialisieren: %s\n"
+
+#, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Konnte %s nicht öffnen: %s\n"
 
@@ -148,6 +152,10 @@ msgid "Could not open ALSA PCM device '%s': %s\n"
 msgstr "Konnte ALSA-PCM-Gerät '%s' nicht öffnen: %s\n"
 
 #, c-format
+msgid "Could not open SDL audio device: %s\n"
+msgstr "Konnte SDL-Audiogerät nicht öffnen: %s\n"
+
+#, c-format
 msgid "Could not open output plugin \"%s\"\n"
 msgstr "Konnte Ausgabemethode \"%s\" nicht öffnen\n"
 
@@ -158,6 +166,14 @@ msgstr "Konnte %s nicht lesen: %s\n"
 #, c-format
 msgid "Could not rename %s to %s: %s\n"
 msgstr "Konnte %s nicht in %s umbenennen: %s\n"
+
+#, c-format
+msgid "Could not stat %s: %s\n"
+msgstr "Konnte Dateiattribute von %s nicht ermitteln: %s\n"
+
+#, c-format
+msgid "Could not write SDL audio data: %s\n"
+msgstr "Konnte SDL-Audiodaten nicht schreiben: %s\n"
 
 #, c-format
 msgid "Default subsong %d is out of range [1..%d].\n"
@@ -301,8 +317,8 @@ msgid "Unknown option %s at %s line %ld.\n"
 msgstr "Unbekannte Option %s in %s Zeile %ld.\n"
 
 #, c-format
-msgid "Unsupported DMG clock: %dHz\n"
-msgstr "Nicht unterstützter DMG-Takt: %dHz\n"
+msgid "Unsupported DMG clock: %ldHz\n"
+msgstr "Nicht unterstützter DMG-Takt: %ldHz\n"
 
 #, c-format
 msgid "Unsupported VGM opcode: 0x%02x\n"

--- a/po/en.po
+++ b/po/en.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.0.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-27 22:20+0200\n"
+"POT-Creation-Date: 2020-11-12 21:14+0100\n"
 "PO-Revision-Date: 2015-07-18 22:22+0200\n"
 "Last-Translator: Tobias Diedrich <ranma+gbsplay@tdiedrich.de>\n"
 "Language-Team: none\n"
@@ -94,16 +94,16 @@ msgstr ""
 "\n"
 
 #, c-format
-msgid "Bad GD3 offset: %08x\n"
-msgstr "Bad GD3 offset: %08x\n"
+msgid "Bad GD3 offset: %08lx\n"
+msgstr "Bad GD3 offset: %08lx\n"
 
 #, c-format
-msgid "Bad data length: %d\n"
-msgstr "Bad data length: %d\n"
+msgid "Bad data length: %ld\n"
+msgstr "Bad data length: %ld\n"
 
 #, c-format
-msgid "Bad file size in header: %d\n"
-msgstr "Bad file size in header: %d\n"
+msgid "Bad file size in header: %ld\n"
+msgstr "Bad file size in header: %ld\n"
 
 #, c-format
 msgid "Bank @0x4000:     %d\n"
@@ -127,6 +127,10 @@ msgid "Copyright:"
 msgstr "Copyright:"
 
 #, c-format
+msgid "Could not init SDL: %s\n"
+msgstr "Could not init SDL: %s\n"
+
+#, c-format
 msgid "Could not open %s: %s\n"
 msgstr "Could not open %s: %s\n"
 
@@ -147,6 +151,10 @@ msgid "Could not open ALSA PCM device '%s': %s\n"
 msgstr "Could not open ALSA PCM device '%s': %s\n"
 
 #, c-format
+msgid "Could not open SDL audio device: %s\n"
+msgstr "Could not open SDL audio device: %s\n"
+
+#, c-format
 msgid "Could not open output plugin \"%s\"\n"
 msgstr "Could not open output plugin \"%s\"\n"
 
@@ -157,6 +165,14 @@ msgstr "Could not read %s: %s\n"
 #, c-format
 msgid "Could not rename %s to %s: %s\n"
 msgstr "Could not rename %s to %s: %s\n"
+
+#, c-format
+msgid "Could not stat %s: %s\n"
+msgstr "Could not stat %s: %s\n"
+
+#, c-format
+msgid "Could not write SDL audio data: %s\n"
+msgstr "Could not write SDL audio data: %s\n"
 
 #, c-format
 msgid "Default subsong %d is out of range [1..%d].\n"
@@ -300,8 +316,8 @@ msgid "Unknown option %s at %s line %ld.\n"
 msgstr "Unknown option %s at %s line %ld.\n"
 
 #, c-format
-msgid "Unsupported DMG clock: %dHz\n"
-msgstr "Unsupported DMG clock: %dHz\n"
+msgid "Unsupported DMG clock: %ldHz\n"
+msgstr "Unsupported DMG clock: %ldHz\n"
 
 #, c-format
 msgid "Unsupported VGM opcode: 0x%02x\n"


### PR DESCRIPTION
Looks good on Linux, tested locally. The build servers concur.

I did a short test with macOS on the build servers (using `brew install sdl2`), but the installation went to `/usr/local/Cellar/sdl2/2.0.12_1` and `configure` did not find it.  We can look into this later, currently SDL is disabled on the builds.

MINGW32 and MINGW64 builds currently break for unknown reasons. Can anybody check this locally and perhaps add a fix?

I used `sdl`, `SDL` and also `SDL2` for constants, variables and texts. I think the given choice makes sense in the given context, but if anybody wants me to streamline this (eg. `SDL2` everywhere), please tell.
