### PR TITLE
Fix DirectSound output plugin buffering

### DIFF
--- a/terminal.c
+++ b/terminal.c
@@ -48,6 +48,7 @@ static void setup_handlers(void)
 	sigaction(SIGSEGV, &sa, NULL);
 	sa.sa_handler = stop_handler;
 	sigaction(SIGSTOP, &sa, NULL);
+	sigaction(SIGABRT, &sa, NULL);
 	sa.sa_handler = cont_handler;
 	sigaction(SIGCONT, &sa, NULL);
 }


### PR DESCRIPTION
While streaming to the DSound driver the plugin would occasionally attempt to lock from the first byte past the end of the sound buffer, receiving null pointers and an error code from the Lock function (then subsequently attempting memcpy on the null pointers).
This resulted in parts of the audio stream to be discarded producing too fast and choppy playback.

Make sure that the write index wraps to 0 when it hits exactly the first address past the end of the buffer.

Some subsequent glitches surfaced after that, such as an odd number of bytes for the buffer size getting allocated on unusual sample rates, leading to endian swap and significant distortion.