### PR TITLE
don't update status display when paused

### DIFF
--- a/gbsplay.c
+++ b/gbsplay.c
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
 		}
 
 		if (redraw) printinfo();
-		if (verbosity>1) printstatus(gbs);
+		if (!pause_mode && verbosity>1) printstatus(gbs);
 		handleuserinput(gbs);
 	}
 

--- a/xgbsplay.c
+++ b/xgbsplay.c
@@ -219,7 +219,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		updatetitle(gbs);
+		if (!pause_mode)
+			updatetitle(gbs);
 	}
 
 	/* stop sound */


### PR DESCRIPTION
This should fix issue #44.

I have not found the root cause for the display problems in the terminal, but there is no need to update the status at all when playback is paused. This saves CPU as well while also preventing messing up the display in any way.