### PR TITLE
Reload envelope volume from NRx2 setting on channel retrigger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -419,7 +419,7 @@ TESTOPTS := -r 44100 -t 30 -f 0 -g 0 -T 0 -H off
 test: gbsplay $(tests) test_gbs
 	@echo Verifying output correctness for examples/nightmode.gbs:
 	$(Q)MD5=`LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH ./gbsplay -c examples/gbsplayrc_sample -E b -o stdout $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null | (md5sum || md5 -r) | cut -f1 -d\ `; \
-	EXPECT="a6f920f9a9ac2bfbd0c7e22bb740db1c"; \
+	EXPECT="da323f60a145ec178781cbd41478d15a"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "Bigendian output ok"; \
 	else \
@@ -429,7 +429,7 @@ test: gbsplay $(tests) test_gbs
 		exit 1; \
 	fi
 	$(Q)MD5=`LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH ./gbsplay -c examples/gbsplayrc_sample -E l -o stdout $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null | (md5sum || md5 -r) | cut -f1 -d\ `; \
-	EXPECT="c82104c3a25fe794df1496d66d9cf24c"; \
+	EXPECT="69ca8706670e91ea1cee0ff9efdf4a9c"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "Littleendian output ok"; \
 	else \

--- a/gbhw.h
+++ b/gbhw.h
@@ -42,6 +42,7 @@ struct gbhw_channel {
 	long rightgate;
 	long lvl;
 	long volume;
+	long env_volume;
 	long env_dir;
 	long env_tc;
 	long env_ctr;

--- a/gbsplay.c
+++ b/gbsplay.c
@@ -147,7 +147,7 @@ static char *notestring(long ch)
 
 	if (gbhw_ch[ch].mute) return "-M-";
 
-	if (gbhw_ch[ch].volume == 0 ||
+	if (gbhw_ch[ch].env_volume == 0 ||
 	    gbhw_ch[ch].master == 0 ||
 	    (gbhw_ch[ch].leftgate == 0 &&
 	     gbhw_ch[ch].rightgate == 0)) return "---";
@@ -167,8 +167,8 @@ static long chvol(long ch)
 	     gbhw_ch[ch].rightgate == 0)) return 0;
 
 	if (ch == 2)
-		v = (3-((gbhw_ch[2].volume+3)&3)) << 2;
-	else v = gbhw_ch[ch].volume;
+		v = (3-((gbhw_ch[2].env_volume+3)&3)) << 2;
+	else v = gbhw_ch[ch].env_volume;
 
 	return v;
 }

--- a/plugout_altmidi.c
+++ b/plugout_altmidi.c
@@ -268,7 +268,7 @@ static int midi_step(long cycles, const struct gbhw_channel chan[])
 
 	for (c = 0; c < 3; c++) {
 		ch = &chan[c];
-		new_playing = ch->running && ch->master && ch->volume;
+		new_playing = ch->running && ch->master && ch->env_volume;
 
 		if (playing[c]) {
 			if (new_playing) {


### PR DESCRIPTION
Currently the last envelope update value is used so a channel remains
silent on retrigger.

When a channel is triggered the volume is supposed to be reset to the
value previously set via the NRx2 register.
To implement the behaviour a property `env_volume` is added to gbhw which
takes the place of the previous `volume`. It is subsequently used to
update sound output, display, etc.

`volume` assumes the value of the actual NRx2 register contents and is
not affected by envelope updates. On channel trigger it is copied to
`env_volume`.

**DISCUSS!**
Live NRx2 writes previously updated the current volume immediately; according to https://gbdev.gg8.se/wiki/articles/Gameboy_sound_hardware#Differences this behaviour is inconsistent between Gameboy models but it doesn't appear to be working as expected in general. Thus the behaviour on NRx2 writes is implicitly changed to update only the stored volume, not the current volume. (gbhw.c:388)