### PR TITLE
add configure flag --build-verbose to enable verbose build

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         compiler: [gcc, clang]
-        flags: ['', --disable-i18n --disable-zlib --prefix=/tmp/gbsplay, --enable-sharedlibgbs, --with-xgbsplay]
+        flags: ['', --disable-i18n --disable-zlib --prefix=/tmp/gbsplay, --enable-sharedlibgbs, --with-xgbsplay --enable-verbosebuild]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         compiler: [gcc, clang]
-        flags: ['']
+        flags: [--enable-verbosebuild]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         msystem: [MSYS, MINGW64, MINGW32]
-        flags: ['', --enable-sharedlibgbs]
+        flags: ['', '--enable-sharedlibgbs --enable-verbosebuild']
         include:
           - msystem: MSYS
             packages: gcc

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,5 @@
 .PHONY: all default distclean clean install dist
 
-ifeq ("$(origin V)", "command line")
-  VERBOSE = $(V)
-endif
-ifndef VERBOSE
-  VERBOSE = 0
-endif
-ifeq ($(VERBOSE),1)
-  Q =
-else
-  Q = @
-endif
-
 all: default
 
 noincludes  := $(patsubst distclean,yes,$(MAKECMDGOALS))
@@ -31,6 +19,21 @@ appdir      := $(prefix)/share/applications
 configured := no
 ifneq ($(noincludes),yes)
 -include config.mk
+endif
+
+ifeq ($(use_verbosebuild),yes)
+  VERBOSE = 1
+endif
+ifeq ("$(origin V)", "command line")
+  VERBOSE = $(V)
+endif
+ifndef VERBOSE
+  VERBOSE = 0
+endif
+ifeq ($(VERBOSE),1)
+  Q =
+else
+  Q = @
 endif
 
 generatedeps := no

--- a/check_buildflags.sh
+++ b/check_buildflags.sh
@@ -61,6 +61,7 @@ i18n=yes
 zlib=yes
 harden=yes
 sharedlib=no
+verbosebuild=no
 xgbsplay=no
 prefix=/usr/local
 
@@ -80,6 +81,9 @@ for flag in "$@"; do
 	    ;;
 	--enable-sharedlibgbs)
 	    sharedlib=yes
+	    ;;
+	--enable-verbosebuild)
+	    verbosebuild=yes
 	    ;;
 	--with-xgbsplay)
 	    xgbsplay=yes
@@ -119,6 +123,8 @@ else
 fi
 
 expect_to_contain use_sharedlibgbs "$sharedlib"
+
+expect_to_contain use_verbosebuild "$verbosebuild"
 
 if [ "$xgbsplay" = yes ]; then
     expect_to_contain EXTRA_INSTALL "xgbsplay"

--- a/configure
+++ b/configure
@@ -517,6 +517,7 @@ Optional Features:
   --disable-zlib         disable transparent gzip decompression
   --enable-debug         build with debug code
   --enable-sharedlibgbs  build libgbs as a shared library
+  --enable-verbosebuild  give verbose output during build
 
 Optional Modules:
   --with-xmmsplugin      build XMMS input plugin
@@ -558,6 +559,7 @@ OPTS="${OPTS} use_pulse"
 OPTS="${OPTS} use_sdl"
 OPTS="${OPTS} use_sharedlibgbs"
 OPTS="${OPTS} use_stdout"
+OPTS="${OPTS} use_verbosebuild"
 OPTS="${OPTS} use_zlib"
 for OPT in $OPTS; do
     eval "${OPT}="
@@ -1121,6 +1123,7 @@ build_xgbsplay
 have_xgettext
 use_i18n
 use_sharedlibgbs
+use_verbosebuild
 windows_build
 windows_libprefix
 libaudio_flags
@@ -1163,6 +1166,18 @@ __EOF__
 (
     echo "s/%%%VERSION%%%/$VERSION/g"
 ) > config.sed
+
+# show configuration if verbose
+
+if [ "$use_verbosebuild" = yes ]; then
+    for file in config.mk config.h config.sed; do
+	echo
+	echo "content of generated $file:"
+	echo "--------"
+	cat $file
+	echo "--------"
+    done
+fi
 
 ## end
 

--- a/configure
+++ b/configure
@@ -1064,6 +1064,7 @@ setdefault appdir      "$prefix/share/applications"
 setdefault sysconfdir  "/etc"
 
 setdefault use_sharedlibgbs no
+setdefault use_verbosebuild no
 setdefault use_debug no
 
 setdefault use_midi yes


### PR DESCRIPTION
* `make V=0` can still override the setting from configure
* I was unsure what to call the new configure flag:
    * Because "verbose build" are two words, `--enable-verbose-build` and `--with-verbose-build` are to unwieldy IMHO.
    * `--build-verbose` does not fit with the other names, but the option itself does not really fit with the others as well
    * Or `--verbose-build`?

Suggestions welcome, changing the name is a simple replacement.
