### PR TITLE
fix valgrind call and uninitialized values

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Check with valgrind
       if: ${{ matrix.flags == '' }}
       run: |
-        valgrind --error-exitcode=1 make test
+        make test TEST_WRAPPER="valgrind --error-exitcode=1"
     - name: Check install and uninstall targets
       run: |
         # add the sudo here and not inside the script

--- a/Makefile
+++ b/Makefile
@@ -429,7 +429,7 @@ TESTOPTS := -r 44100 -t 30 -f 0 -g 0 -T 0 -H off
 
 test: gbsplay $(tests) test_gbs
 	@echo Verifying output correctness for examples/nightmode.gbs:
-	$(Q)MD5=`LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH ./gbsplay -c examples/gbsplayrc_sample -E b -o stdout $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null | (md5sum || md5 -r) | cut -f1 -d\ `; \
+	$(Q)MD5=`LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH $(TEST_WRAPPER) ./gbsplay -c examples/gbsplayrc_sample -E b -o stdout $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null | (md5sum || md5 -r) | cut -f1 -d\ `; \
 	EXPECT="da323f60a145ec178781cbd41478d15a"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "Bigendian output ok"; \
@@ -439,7 +439,7 @@ test: gbsplay $(tests) test_gbs
 		echo "  Got:      $$MD5" ; \
 		exit 1; \
 	fi
-	$(Q)MD5=`LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH ./gbsplay -c examples/gbsplayrc_sample -E l -o stdout $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null | (md5sum || md5 -r) | cut -f1 -d\ `; \
+	$(Q)MD5=`LD_LIBRARY_PATH=.:$$LD_LIBRARY_PATH $(TEST_WRAPPER) ./gbsplay -c examples/gbsplayrc_sample -E l -o stdout $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null | (md5sum || md5 -r) | cut -f1 -d\ `; \
 	EXPECT="69ca8706670e91ea1cee0ff9efdf4a9c"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "Littleendian output ok"; \

--- a/terminal_posix.c
+++ b/terminal_posix.c
@@ -71,5 +71,5 @@ void restore_terminal(void)
 
 long get_input(char *c)
 {
-	return read(STDIN_FILENO, c, 1) != -1;
+	return read(STDIN_FILENO, c, 1) == 1;
 }

--- a/terminal_posix.c
+++ b/terminal_posix.c
@@ -16,6 +16,7 @@
 #include <signal.h>
 #include <fcntl.h>
 
+static long terminit;
 static struct termios ots;
 
 void exit_handler(int signum)
@@ -57,16 +58,20 @@ void setup_terminal(void)
 
 	setup_handlers();
 
-	tcgetattr(STDIN_FILENO, &ts);
+	if (tcgetattr(STDIN_FILENO, &ts) == -1)
+		return;
+
 	ots = ts;
 	ts.c_lflag &= ~(ICANON | ECHO | ECHONL);
 	tcsetattr(STDIN_FILENO, TCSAFLUSH, &ts);
 	fcntl(STDIN_FILENO, F_SETFL, O_NONBLOCK);
+	terminit = 1;
 }
 
 void restore_terminal(void)
 {
-	tcsetattr(STDIN_FILENO, TCSAFLUSH, &ots);
+	if (terminit)
+		tcsetattr(STDIN_FILENO, TCSAFLUSH, &ots);
 }
 
 long get_input(char *c)


### PR DESCRIPTION
* Fix valgrind to check the gbsplay executable instead of make. Achieved via TEST_WRAPPER Makefile variable.
* Valgrind then reported two usages of uninitialized values which could both be fixed by changing the surrounding code to remove the affected code flow branches.

Remaining valgrind warnings:
```
==8848== Warning: ignored attempt to set SIGSTOP handler in sigaction();
==8848==          the SIGSTOP signal is uncatchable
==8848== 
==8848== HEAP SUMMARY:
==8848==     in use at exit: 8,400 bytes in 2 blocks
==8848==   total heap usage: 282 allocs, 280 frees, 123,965 bytes allocated

```