### PR TITLE
refactor metadata access in libgbs.h

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,6 +6,9 @@ coverage:
   precision: 2
   round: down
   range: "70...100"
+  status:
+    project: false
+    patch: false
 
 parsers:
   gcov:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,21 @@
+---
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: true
+      loop: true
+      method: false
+      macro: false
+
+comment:
+  layout: "flags,files"
+  behavior: default
+  require_changes: false

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ libgbs
 *.a
 *.dll
 *.so
+*.so.?
+*.so.?.ver
 *.pot
 gbsinfo
 gbsplay

--- a/gbs.c
+++ b/gbs.c
@@ -97,6 +97,7 @@ struct gbs {
 	gbs_nextsubsong_cb nextsubsong_cb;
 	void *nextsubsong_cb_priv;
 
+	struct gbs_metadata metadata;
 	struct gbs_channel_status step_cb_channels[4];
 	struct gbs_status status; // note: this contains a separate gbs_channel_status[] to not interfere with the step callback
 	struct gbhw_buffer gbhw_buf;
@@ -104,19 +105,12 @@ struct gbs {
 	struct mapper *mapper;
 };
 
-const char *gbs_get_title(struct gbs *gbs)
+const struct gbs_metadata *gbs_get_metadata(struct gbs *gbs)
 {
-	return gbs->title;
-}
-
-const char *gbs_get_author(struct gbs *gbs)
-{
-	return gbs->author;
-}
-
-const char *gbs_get_copyright(struct gbs *gbs)
-{
-	return gbs->copyright;
+	gbs->metadata.title = gbs->title;
+	gbs->metadata.author = gbs->author;
+	gbs->metadata.copyright = gbs->copyright;
+	return &gbs->metadata;
 }
 
 static void update_status_on_subsong_change(struct gbs *gbs);

--- a/gbs.c
+++ b/gbs.c
@@ -1210,4 +1210,5 @@ struct gbs_internal_api gbs_internal_api = {
 version: GBS_VERSION,
 get_bootrom: gbs_get_bootrom,
 write_rom: gbs_write_rom,
+print_info: gbs_print_info,
 };

--- a/gbs_internal.h
+++ b/gbs_internal.h
@@ -22,11 +22,13 @@
 
 typedef const uint8_t* (get_bootrom_fn)(void);
 typedef void (write_rom_fn)(struct gbs *gbs, FILE *out, const uint8_t *logo_data);
+typedef void (print_info_fn)(struct gbs *gbs, long verbose);
 
 struct gbs_internal_api {
 	const char *version;
 	get_bootrom_fn *get_bootrom;
 	write_rom_fn *write_rom;
+	print_info_fn *print_info;
 };
 
 extern struct gbs_internal_api gbs_internal_api;

--- a/gbs_internal.h
+++ b/gbs_internal.h
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2020-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
  */

--- a/gbsinfo.c
+++ b/gbsinfo.c
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2020 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2003-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *                  Christian Garbs <mitch@cgarbs.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
@@ -16,6 +16,7 @@
 #include "gbhw.h"
 #include "gbcpu.h"
 #include "libgbs.h"
+#include "gbs_internal.h"
 
 /* global variables */
 char *myname;
@@ -73,7 +74,7 @@ int main(int argc, char **argv)
         }
 
 	if ((gbs = gbs_open(argv[0])) == NULL) exit(EXIT_FAILURE);
-	gbs_print_info(gbs, 1);
+	gbs_internal_api.print_info(gbs, 1);
 	gbs_close(gbs);
 
 	return 0;

--- a/libgbs.h
+++ b/libgbs.h
@@ -191,7 +191,7 @@ void gbs_set_io_callback(struct gbs *gbs, gbs_io_cb fn, void *priv);
 void gbs_set_step_callback(struct gbs *gbs, gbs_step_cb fn, void *priv);
 void gbs_set_sound_callback(struct gbs *gbs, gbs_sound_cb fn, void *priv);
 long gbs_set_filter(struct gbs *gbs, enum gbs_filter_type type);
-void gbs_print_info(struct gbs *gbs, long verbose);
+void gbs_print_info(struct gbs *gbs, long verbose); // FIXME: export via metadata, don't access stdout from lib!
 long gbs_toggle_mute(struct gbs *gbs, long channel);
 void gbs_close(struct gbs *gbs);
 long gbs_write(struct gbs *gbs, char *name);

--- a/libgbs.h
+++ b/libgbs.h
@@ -46,6 +46,16 @@
 struct gbs;
 
 /**
+ * GBS metadata.  Contains static information about the GBS file like
+ * title and copyright.
+ */
+struct gbs_metadata {
+	const char *title;
+	const char *author;
+	const char *copyright;
+};
+
+/**
  * Sound output buffer.  Contains the next bit of calculated sound
  * output that can be passed to an audio driver or be processed
  * otherwise.
@@ -171,9 +181,7 @@ struct gbs *gbs_open(const char *name);
 void gbs_configure(struct gbs *gbs, long subsong, long subsong_timeout, long silence_timeout, long subsong_gap, long fadeout);
 void gbs_configure_channels(struct gbs *gbs, long mute_0, long mute_1, long mute_2, long mute_3);
 void gbs_configure_output(struct gbs *gbs, struct gbs_output_buffer *buf, long rate);
-const char *gbs_get_title(struct gbs *gbs);
-const char *gbs_get_author(struct gbs *gbs);
-const char *gbs_get_copyright(struct gbs *gbs);
+const struct gbs_metadata *gbs_get_metadata(struct gbs *gbs);
 long gbs_init(struct gbs *gbs, long subsong);
 uint8_t gbs_io_peek(struct gbs *gbs, uint16_t addr);
 const struct gbs_status* gbs_get_status(struct gbs *gbs);

--- a/libgbs.h
+++ b/libgbs.h
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2020 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2003-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *                  Christian Garbs <mitch@cgarbs.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
@@ -191,7 +191,6 @@ void gbs_set_io_callback(struct gbs *gbs, gbs_io_cb fn, void *priv);
 void gbs_set_step_callback(struct gbs *gbs, gbs_step_cb fn, void *priv);
 void gbs_set_sound_callback(struct gbs *gbs, gbs_sound_cb fn, void *priv);
 long gbs_set_filter(struct gbs *gbs, enum gbs_filter_type type);
-void gbs_print_info(struct gbs *gbs, long verbose); // FIXME: export via metadata, don't access stdout from lib!
 long gbs_toggle_mute(struct gbs *gbs, long channel);
 void gbs_close(struct gbs *gbs);
 long gbs_write(struct gbs *gbs, char *name);

--- a/libgbs_whitelist.txt
+++ b/libgbs_whitelist.txt
@@ -2,10 +2,8 @@ gbs_close
 gbs_configure
 gbs_configure_channels
 gbs_configure_output
-gbs_get_author
-gbs_get_copyright
+gbs_get_metadata
 gbs_get_status
-gbs_get_title
 gbs_init
 gbs_io_peek
 gbs_open

--- a/player.c
+++ b/player.c
@@ -3,7 +3,7 @@
  *
  * This file contains the player code common to both CLI and X11 frontends.
  *
- * 2003-2020 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2003-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *                  Christian Garbs <mitch@cgarbs.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
@@ -17,6 +17,8 @@
 
 #include "util.h"
 #include "cfgparser.h"
+#include "libgbs.h"
+#include "gbs_internal.h"
 
 #include "player.h"
 
@@ -605,7 +607,7 @@ struct gbs *common_init(int argc, char **argv)
 	initial_subsong = setup_playmode(gbs);
 	play_subsong(gbs, initial_subsong);
 	if (verbosity>0) {
-		gbs_print_info(gbs, 0);
+		gbs_internal_api.print_info(gbs, 0);
 	}
 
 	return gbs;

--- a/xgbsplay.c
+++ b/xgbsplay.c
@@ -54,7 +54,6 @@
 
 /* global variables */
 static char statustext[STATUSTEXT_LENGTH];
-static char oldstatustext[STATUSTEXT_LENGTH];
 
 static long quit = 0;
 static long screen_dirty = 0;
@@ -109,11 +108,8 @@ static void updatetitle(struct gbs *gbs)
 		 filename, status->subsong+1, status->songs,
 		 time.played_min, time.played_sec, time.total_min, time.total_sec);
 
-	if (strncmp(statustext, oldstatustext, STATUSTEXT_LENGTH) != 0) {  /* or use sizeof(statustext) ?? or strcmp() ?? */
-		strncpy(oldstatustext, statustext, STATUSTEXT_LENGTH);
-		xcb_icccm_set_wm_name(conn, window, XCB_ATOM_STRING, XCB_STRING_FORMAT, len, statustext);
-		xcb_flush(conn);
-	}
+	xcb_icccm_set_wm_name(conn, window, XCB_ATOM_STRING, XCB_STRING_FORMAT, len, statustext);
+	xcb_flush(conn);
 }
 
 void exit_handler(int signum)
@@ -502,8 +498,6 @@ int main(int argc, char **argv)
 			quit = 1;
 			break;
 		}
-		if (is_running())
-			updatetitle(gbs);
 
 		while ((event = xcb_poll_for_event(conn))) {
 			switch (event->response_type & XCB_EVENT_MASK) {
@@ -580,6 +574,7 @@ int main(int argc, char **argv)
 			screen_modified = 0;
 		}
 		if (is_running() && has_status_changed(gbs)) {
+			updatetitle(gbs);
 			screen_dirty = 1;
 		}
 		if (screen_dirty) {

--- a/xgbsplay.c
+++ b/xgbsplay.c
@@ -210,6 +210,7 @@ static void draw_screen_linef(double vx, double vy, const char *fmt, ...)
 static void draw_screen_content(struct gbs *gbs)
 {
 	const struct gbs_status *status = gbs_get_status(gbs);
+	const struct gbs_metadata *metadata = gbs_get_metadata(gbs);
 	struct displaytime time;
 
 	update_displaytime(&time, status);
@@ -219,9 +220,9 @@ static void draw_screen_content(struct gbs *gbs)
 	cairo_select_font_face(cr, "Biwidth", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
 	cairo_set_font_size(cr, 16);
 
-	draw_screen_line(0, 0, gbs_get_title(gbs));
-	draw_screen_line(0, 1, gbs_get_author(gbs));
-	draw_screen_line(0, 2, gbs_get_copyright(gbs));
+	draw_screen_line(0, 0, metadata->title);
+	draw_screen_line(0, 1, metadata->author);
+	draw_screen_line(0, 2, metadata->copyright);
 
 	draw_screen_linef(0, 4, "Song %3d/%3d", status->subsong+1, status->songs);
 	draw_screen_linef(0, 5, "%02ld:%02ld/%02ld:%02ld", time.played_min, time.played_sec, time.total_min, time.total_sec);

--- a/xgbsplay.c
+++ b/xgbsplay.c
@@ -75,6 +75,8 @@ static xcb_atom_t atomWmDeleteWindow = XCB_ATOM_NONE;
 static xcb_atom_t atomWmProtocols = XCB_ATOM_NONE;
 static xcb_atom_t atomWmName = XCB_ATOM_NONE;
 
+static const struct gbs_metadata *metadata;
+
 static void updatetitle(struct gbs *gbs)
 {
 	const struct gbs_status *status = gbs_get_status(gbs);
@@ -210,7 +212,6 @@ static void draw_screen_linef(double vx, double vy, const char *fmt, ...)
 static void draw_screen_content(struct gbs *gbs)
 {
 	const struct gbs_status *status = gbs_get_status(gbs);
-	const struct gbs_metadata *metadata = gbs_get_metadata(gbs);
 	struct displaytime time;
 
 	update_displaytime(&time, status);
@@ -430,6 +431,7 @@ int main(int argc, char **argv)
 	struct sigaction sa;
 
 	gbs = common_init(argc, argv);
+	metadata = gbs_get_metadata(gbs);
 
 	/* init signal handlers */
 	memset(&sa, 0, sizeof(sa));

--- a/xgbsplay.c
+++ b/xgbsplay.c
@@ -594,7 +594,6 @@ int main(int argc, char **argv)
 				}
 			}
 		}
-		updatetitle(gbs);
 	}
 
 	/* stop sound */

--- a/xgbsplay.c
+++ b/xgbsplay.c
@@ -94,7 +94,7 @@ static long has_status_changed(struct gbs *gbs) {
 	return 0;
 }
 
-static void updatetitle(struct gbs *gbs)
+static void update_title(struct gbs *gbs)
 {
 	const struct gbs_status *status = gbs_get_status(gbs);
 	struct displaytime time;
@@ -574,7 +574,7 @@ int main(int argc, char **argv)
 			screen_modified = 0;
 		}
 		if (is_running() && has_status_changed(gbs)) {
-			updatetitle(gbs);
+			update_title(gbs);
 			screen_dirty = 1;
 		}
 		if (screen_dirty) {


### PR DESCRIPTION
plus some refactoring in xgbsplay

I have one question, so I did not commit directly to master:

To decouple the internal metadata in `gbs.c` from the external metadata in `libgbs.h`, the three fields title/author/copyright get copied around in `gbs_get_metadata()` (or at least their pointers get copied around):
https://github.com/mmitch/gbsplay/blob/7727a30a49ffe614e3441e2224d0975eff230b7f/gbs.c#L107-L113

Is this good?
Or should we just use `struct gbs->metadata->...` internally and remove `struct gbs->title`, `struct gbs->author` and `struct gbs->copyright` altogether?
