### PR TITLE
replace 'echo -n' by 'printf'

### DIFF
--- a/check_buildflags.sh
+++ b/check_buildflags.sh
@@ -2,7 +2,7 @@
 #
 # Ensure that configure enabled the plugouts as it was expected to.
 #
-# 2020 (C) by Christian Garbs <mitch@cgarbs.de>
+# 2020-2021 (C) by Christian Garbs <mitch@cgarbs.de>
 # Licensed under GNU GPL v1 or, at your option, any later version.
 
 set -e
@@ -38,7 +38,7 @@ expect_to_contain()
 {
     local key="$1" expected="$2"
     
-    echo -n "check <$key> to contain <$expected> .. "
+    printf 'check <%s> to contain <%s> .. ' "$key" "$expected"
     if ! key_contains "$key" "$expected"; then
 	die "expected value <$expected> not found in key <$key>"
     fi
@@ -49,7 +49,7 @@ expect_to_not_contain()
 {
     local key="$1" unexpected="$2"
 
-    echo -n "check <$key> to not contain <$unexpected> .. "
+    printf 'check <%s> to not contain <%s> .. ' "$key" "$unexpected"
     if key_contains "$key" "$unexpected"; then
 	die "unexpected value <$unexpected> found in key <$key>"
     fi

--- a/check_install_uninstall.sh
+++ b/check_install_uninstall.sh
@@ -38,7 +38,7 @@ expect_content_to_be_equal()
 {
     local file_a="$1" file_b="$2"
 
-    echo -n "compare <$file_a> to <$file_b> .. "
+    printf 'compare <%s> to <%s> .. ' "$file_a" "$file_b"
     if ! cmp --quiet "$file_a" "$file_b"; then
 	echo "ERROR"
 	echo "expected content of <$file_a> and <$file_b> to be equal, but file contents differ:"
@@ -52,7 +52,7 @@ expect_content_to_be_different()
 {
     local file_a="$1" file_b="$2"
 
-    echo -n "compare <$file_a> to <$file_b> .. "
+    printf 'compare <%s> to <%s> .. ' "$file_a" "$file_b"
     if cmp --quiet "$file_a" "$file_b"; then
 	echo "ERROR"
 	echo "expected content of <$file_a> and <$file_b> to be different, but file contents are equal"

--- a/check_plugouts.sh
+++ b/check_plugouts.sh
@@ -2,7 +2,7 @@
 #
 # Ensure that configure enabled the plugouts as it was expected to.
 #
-# 2020 (C) by Christian Garbs <mitch@cgarbs.de>
+# 2020-2021 (C) by Christian Garbs <mitch@cgarbs.de>
 # Licensed under GNU GPL v1 or, at your option, any later version.
 
 set -e
@@ -51,7 +51,7 @@ echo "checking config.mk"
 
 # check that all expected plugouts are present
 for expected in "${expected_plugouts[@]}"; do
-    echo -n "check expected <$expected> to be enabled .. "
+    printf 'check expected <%s> to be enabled .. ' "$expected"
     if ! is_contained_in "$expected" "${enabled_plugouts[@]}"; then
 	die "expected plugout <$expected> has not been enabled by configure"
     fi
@@ -60,7 +60,7 @@ done
 
 # check that no unexpected plugouts are present
 for enabled in "${enabled_plugouts[@]}"; do
-    echo -n "check enabled <$enabled> to be expected .. "
+    printf 'check enabled <%s> to be expected .. ' "$enabled"
     if ! is_contained_in "$enabled" "${expected_plugouts[@]}" ; then
 	die "unexpected plugout <$enabled> has been enabled by configure"
     fi


### PR DESCRIPTION
'echo -n' is not available everywhere, while 'printf' without a linebreak does the same and is defined by POSIX
see
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html#tag_20_37_16
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html#tag_20_94_18

Do we want this?  It makes the code a little bit more complicated, but only in scripts used for the build pipelines.
As the build pipelines all work with 'echo -n', is this even needed?

I'm happy to retract this pull request, I currently can't make up my mind.
Need a second opinion ;-)