### PR TITLE
use more 'const'

### DIFF
--- a/cfgparser.c
+++ b/cfgparser.c
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2020 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2003-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *                  Christian Garbs <mitch@cgarbs.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
@@ -61,7 +61,7 @@ static long nextstate;
 static long c;
 static const char *filename;
 
-static void err_expect(char *s)
+static void err_expect(const char* const s)
 {
 	fprintf(stderr, _("'%s' expected at %s line %ld char %ld.\n"),
 	        s, filename, cfg_line, cfg_char);
@@ -70,7 +70,7 @@ static void err_expect(char *s)
 	nextstate = 1;
 }
 
-void cfg_endian(void *ptr)
+void cfg_endian(void* const ptr)
 {
 	enum plugout_endian *endian = ptr;
 
@@ -91,7 +91,7 @@ void cfg_endian(void *ptr)
 	nextstate = 1;
 }
 
-void cfg_string(void *ptr)
+void cfg_string(void * const ptr)
 {
 	char s[200];
 	unsigned long n = 0;
@@ -113,7 +113,7 @@ void cfg_string(void *ptr)
 	nextstate = 1;
 }
 
-void cfg_long(void *ptr)
+void cfg_long(void* const ptr)
 {
 	char num[20];
 	unsigned long n = 0;
@@ -135,7 +135,7 @@ void cfg_long(void *ptr)
 	nextstate = 1;
 }
 
-void cfg_parse(const char *fname, const struct cfg_option *options)
+void cfg_parse(const char* const fname, const struct cfg_option* const options)
 {
 	char option[200] = "";
 
@@ -204,7 +204,7 @@ void cfg_parse(const char *fname, const struct cfg_option *options)
 	(void)fclose(cfg_file);
 }
 
-char* get_userconfig(const char* cfgfile)
+char* get_userconfig(const char* const cfgfile)
 {
 	char *homedir, *usercfg;
 	long length;

--- a/cfgparser.h
+++ b/cfgparser.h
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2020 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2003-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *                  Christian Garbs <mitch@cgarbs.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
@@ -10,18 +10,18 @@
 #ifndef _CFGPARSER_H_
 #define _CFGPARSER_H_
 
-typedef void (*cfg_parse_fn)(void *ptr);
+typedef void (*cfg_parse_fn)(void* const ptr);
 
 struct cfg_option {
-	char *name;
-	void *ptr;
-	cfg_parse_fn parse_fn;
+	const char* const name;
+	void* const ptr;
+	const cfg_parse_fn parse_fn;
 };
 
-void  cfg_string(void *ptr);
-void  cfg_long(void *ptr);
-void  cfg_endian(void *ptr);
-void  cfg_parse(const char *fname, const struct cfg_option *options);
-char* get_userconfig(const char* cfgfile);
+void  cfg_string(void* const ptr);
+void  cfg_long(void* const ptr);
+void  cfg_endian(void* const ptr);
+void  cfg_parse(const char* const fname, const struct cfg_option* const options);
+char* get_userconfig(const char* const cfgfile);
 
 #endif

--- a/common.h
+++ b/common.h
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2020 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2003-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
  */
@@ -56,7 +56,7 @@
 
 #  if GBS_PRESERVE_TEXTDOMAIN == 1
 
-static inline char* _(const char *msgid)
+static inline char* _(const char* const msgid)
 {
 	char *olddomain = textdomain(NULL);
 	char *olddir = bindtextdomain(olddomain, NULL);
@@ -71,7 +71,7 @@ static inline char* _(const char *msgid)
 
 #  else
 
-static inline char* _(const char *msgid)
+static inline char* _(const char* const msgid)
 {
 	return gettext(msgid);
 }

--- a/gbcpu.c
+++ b/gbcpu.c
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2020 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2003-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *                  Christian Garbs <mitch@cgarbs.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
@@ -29,11 +29,11 @@ static const char *conds[4] = {
 
 struct opinfo;
 
-typedef void (*ex_fn)(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi);
+typedef void (*ex_fn)(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi);
 
 struct opinfo {
 #if DEBUG == 1 || defined(S_SPLINT_S)
-	const char *name;
+	const char* const name;
 #endif
 	const ex_fn fn;
 #if DEBUG == 1
@@ -56,38 +56,38 @@ static void none_put(void *priv, uint32_t addr, uint8_t val)
 	UNUSED(val);
 }
 
-void gbcpu_init_struct(struct gbcpu *gbcpu) {
+void gbcpu_init_struct(struct gbcpu* const gbcpu) {
 	for (uint16_t i = 0; i < GBCPU_LOOKUP_SIZE; i++) {
 		gbcpu->getlookup[i].get = &none_get;
 		gbcpu->putlookup[i].put = &none_put;
 	}
 }
 
-static inline uint32_t mem_get(struct gbcpu *gbcpu, uint32_t addr)
+static inline uint32_t mem_get(struct gbcpu* const gbcpu, uint32_t addr)
 {
 	struct get_entry *e = &gbcpu->getlookup[(addr >> 8) & 0xff];
 	gbcpu->cycles += 4;
 	return e->get(e->priv, addr);
 }
 
-static inline void mem_put(struct gbcpu *gbcpu, uint32_t addr, uint32_t val)
+static inline void mem_put(struct gbcpu* const gbcpu, uint32_t addr, uint32_t val)
 {
 	struct put_entry *e = &gbcpu->putlookup[(addr >> 8) & 0xff];
 	gbcpu->cycles += 4;
 	e->put(e->priv, addr, val);
 }
 
-uint8_t gbcpu_mem_get(struct gbcpu *gbcpu, uint16_t addr)
+uint8_t gbcpu_mem_get(struct gbcpu* const gbcpu, uint16_t addr)
 {
 	return mem_get(gbcpu, addr);
 }
 
-void gbcpu_mem_put(struct gbcpu *gbcpu, uint16_t addr, uint8_t val)
+void gbcpu_mem_put(struct gbcpu* const gbcpu, uint16_t addr, uint8_t val)
 {
 	mem_put(gbcpu, addr, val);
 }
 
-static void push(struct gbcpu *gbcpu, uint32_t val)
+static void push(struct gbcpu* const gbcpu, uint32_t val)
 {
 	uint32_t sp = REGS16_R(gbcpu->regs, SP) - 2;
 	REGS16_W(gbcpu->regs, SP, sp);
@@ -95,7 +95,7 @@ static void push(struct gbcpu *gbcpu, uint32_t val)
 	mem_put(gbcpu, sp+1, val >> 8);
 }
 
-static uint32_t pop(struct gbcpu *gbcpu)
+static uint32_t pop(struct gbcpu* const gbcpu)
 {
 	uint32_t res;
 	uint32_t sp = REGS16_R(gbcpu->regs, SP);
@@ -107,7 +107,7 @@ static uint32_t pop(struct gbcpu *gbcpu)
 	return res;
 }
 
-static uint32_t get_imm8(struct gbcpu *gbcpu)
+static uint32_t get_imm8(struct gbcpu* const gbcpu)
 {
 	uint32_t pc = REGS16_R(gbcpu->regs, PC);
 	uint32_t res;
@@ -117,7 +117,7 @@ static uint32_t get_imm8(struct gbcpu *gbcpu)
 	return res;
 }
 
-static uint32_t get_imm16(struct gbcpu *gbcpu)
+static uint32_t get_imm16(struct gbcpu* const gbcpu)
 {
 	uint32_t pc = REGS16_R(gbcpu->regs, PC);
 	uint32_t res;
@@ -133,28 +133,28 @@ static inline void print_reg(long i)
 	else DPRINTF("%c", regnames[i]);
 }
 
-static uint32_t get_reg(struct gbcpu *gbcpu, long i)
+static uint32_t get_reg(struct gbcpu* const gbcpu, long i)
 {
 	if (i == 6) /* indirect memory access by [HL] */
 		return mem_get(gbcpu, REGS16_R(gbcpu->regs, HL));
 	return REGS8_R(gbcpu->regs, i);
 }
 
-static void put_reg(struct gbcpu *gbcpu, long i, uint32_t val)
+static void put_reg(struct gbcpu* const gbcpu, long i, uint32_t val)
 {
 	if (i == 6) /* indirect memory access by [HL] */
 		mem_put(gbcpu, REGS16_R(gbcpu->regs, HL), val);
 	else REGS8_W(gbcpu->regs, i, val);
 }
 
-static void op_unknown(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_unknown(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(oi);
 	fprintf(stderr, "\n\nUnknown opcode %02x.\n", (unsigned char)op);
 	gbcpu->stopped = 1;
 }
 
-static void op_set(struct gbcpu *gbcpu, uint32_t op)
+static void op_set(struct gbcpu* const gbcpu, uint32_t op)
 {
 	long reg = op & 7;
 	unsigned long bit = (op >> 3) & 7;
@@ -164,7 +164,7 @@ static void op_set(struct gbcpu *gbcpu, uint32_t op)
 	put_reg(gbcpu, reg, get_reg(gbcpu, reg) | (1 << bit));
 }
 
-static void op_res(struct gbcpu *gbcpu, uint32_t op)
+static void op_res(struct gbcpu* const gbcpu, uint32_t op)
 {
 	long reg = op & 7;
 	unsigned long bit = (op >> 3) & 7;
@@ -174,7 +174,7 @@ static void op_res(struct gbcpu *gbcpu, uint32_t op)
 	put_reg(gbcpu, reg, get_reg(gbcpu, reg) & ~(1 << bit));
 }
 
-static void op_bit(struct gbcpu *gbcpu, uint32_t op)
+static void op_bit(struct gbcpu* const gbcpu, uint32_t op)
 {
 	long reg = op & 7;
 	unsigned long bit = (op >> 3) & 7;
@@ -186,7 +186,7 @@ static void op_bit(struct gbcpu *gbcpu, uint32_t op)
 	gbcpu->regs.rn.f ^= ((get_reg(gbcpu, reg) << 8) >> (bit+1)) & ZF;
 }
 
-static void op_rl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_rl(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	/* C <- rrrrrrrr <-
 	 * |              |
@@ -207,7 +207,7 @@ static void op_rl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	put_reg(gbcpu, reg, res);
 }
 
-static void op_rla(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_rla(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	/* C <- aaaaaaaa <-
 	 * |              |
@@ -226,7 +226,7 @@ static void op_rla(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->regs.rn.a = res;
 }
 
-static void op_rlc(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_rlc(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	/* C <- rrrrrrrr <-
 	 *    |           |
@@ -247,7 +247,7 @@ static void op_rlc(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	put_reg(gbcpu, reg, res);
 }
 
-static void op_rlca(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_rlca(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	/* C <- aaaaaaaa <-
 	 *    |           |
@@ -266,7 +266,7 @@ static void op_rlca(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->regs.rn.a = res;
 }
 
-static void op_sla(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_sla(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = op & 7;
 	uint8_t res, val;
@@ -282,7 +282,7 @@ static void op_sla(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	put_reg(gbcpu, reg, res);
 }
 
-static void op_rr(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_rr(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = op & 7;
 	uint8_t res, val;
@@ -299,7 +299,7 @@ static void op_rr(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	put_reg(gbcpu, reg, res);
 }
 
-static void op_rra(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_rra(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t res;
 
@@ -314,7 +314,7 @@ static void op_rra(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->regs.rn.a = res;
 }
 
-static void op_rrc(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_rrc(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = op & 7;
 	uint8_t res, val;
@@ -331,7 +331,7 @@ static void op_rrc(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	put_reg(gbcpu, reg, res);
 }
 
-static void op_rrca(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_rrca(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t res;
 
@@ -346,7 +346,7 @@ static void op_rrca(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->regs.rn.a = res;
 }
 
-static void op_sra(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_sra(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = op & 7;
 	uint8_t res, val;
@@ -363,7 +363,7 @@ static void op_sra(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	put_reg(gbcpu, reg, res);
 }
 
-static void op_srl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_srl(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = op & 7;
 	uint8_t res, val;
@@ -379,7 +379,7 @@ static void op_srl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	put_reg(gbcpu, reg, res);
 }
 
-static void op_swap(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_swap(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = op & 7;
 	uint32_t res;
@@ -408,7 +408,7 @@ static const struct opinfo cbops[8] = {
 	OPINFO("SRL",  &op_srl,  0, 0),		/* opcode cb38-cb3f */
 };
 
-static void op_cbprefix(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_cbprefix(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint16_t pc = REGS16_R(gbcpu->regs, PC);
 
@@ -427,7 +427,7 @@ static void op_cbprefix(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *o
 	gbcpu->stopped = 1;
 }
 
-static void op_ld(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ld(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long src = op & 7;
 	long dst = (op >> 3) & 7;
@@ -441,7 +441,7 @@ static void op_ld(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	put_reg(gbcpu, dst, get_reg(gbcpu, src));
 }
 
-static void op_ld_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ld_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long ofs = get_imm16(gbcpu);
 
@@ -452,7 +452,7 @@ static void op_ld_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->regs.rn.a = mem_get(gbcpu, ofs);
 }
 
-static void op_ld_ind16_a(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ld_ind16_a(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long ofs = get_imm16(gbcpu);
 
@@ -463,7 +463,7 @@ static void op_ld_ind16_a(struct gbcpu *gbcpu, uint32_t op, const struct opinfo 
 	mem_put(gbcpu, ofs, gbcpu->regs.rn.a);
 }
 
-static void op_ld_ind16_sp(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ld_ind16_sp(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long ofs = get_imm16(gbcpu);
 	long sp = REGS16_R(gbcpu->regs, SP);
@@ -476,7 +476,7 @@ static void op_ld_ind16_sp(struct gbcpu *gbcpu, uint32_t op, const struct opinfo
 	mem_put(gbcpu, ofs+1, sp >> 8);
 }
 
-static void op_ld_hlsp(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ld_hlsp(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	int8_t ofs = get_imm8(gbcpu);
 	uint16_t old = REGS16_R(gbcpu->regs, SP);
@@ -496,7 +496,7 @@ static void op_ld_hlsp(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi
 	gbcpu->cycles += 4;
 }
 
-static void op_ld_sphl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ld_sphl(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(op);
 	UNUSED(oi);
@@ -507,7 +507,7 @@ static void op_ld_sphl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi
 	gbcpu->cycles += 4;
 }
 
-static void op_ld_reg16_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ld_reg16_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long val = get_imm16(gbcpu);
 	long reg = (op >> 4) & 3;
@@ -519,7 +519,7 @@ static void op_ld_reg16_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinf
 	REGS16_W(gbcpu->regs, reg, val);
 }
 
-static void op_ld_reg16_a(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ld_reg16_a(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = (op >> 4) & 3;
 	uint16_t r;
@@ -541,7 +541,7 @@ static void op_ld_reg16_a(struct gbcpu *gbcpu, uint32_t op, const struct opinfo 
 	}
 }
 
-static void op_ld_reg8_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ld_reg8_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long val = get_imm8(gbcpu);
 	long reg = (op >> 3) & 7;
@@ -554,7 +554,7 @@ static void op_ld_reg8_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo
 	DPRINTF(", 0x%02lx", val);
 }
 
-static void op_ldh(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ldh(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long ofs = op & 2 ? 0 : get_imm8(gbcpu);
 
@@ -580,7 +580,7 @@ static void op_ldh(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	}
 }
 
-static void op_inc(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_inc(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = (op >> 3) & 7;
 	uint8_t res;
@@ -598,7 +598,7 @@ static void op_inc(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if ((old & 15) > (res & 15)) gbcpu->regs.rn.f |= HF;
 }
 
-static void op_inc16(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_inc16(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = (op >> 4) & 3;
 	uint16_t res;
@@ -615,7 +615,7 @@ static void op_inc16(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->cycles += 4;
 }
 
-static void op_dec(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_dec(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = (op >> 3) & 7;
 	uint8_t res;
@@ -634,7 +634,7 @@ static void op_dec(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if ((old & 15) < (res & 15)) gbcpu->regs.rn.f |= HF;
 }
 
-static void op_dec16(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_dec16(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = (op >> 4) & 3;
 	uint16_t res;
@@ -651,7 +651,7 @@ static void op_dec16(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->cycles += 4;
 }
 
-static void op_add_sp_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_add_sp_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	int8_t imm = get_imm8(gbcpu);
 	uint16_t old = REGS16_R(gbcpu->regs, SP);
@@ -671,7 +671,7 @@ static void op_add_sp_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo 
 	gbcpu->cycles += 8;
 }
 
-static void op_add(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_add(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t old = gbcpu->regs.rn.a;
 	uint8_t new;
@@ -688,7 +688,7 @@ static void op_add(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if (new == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_add_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_add_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t imm = get_imm8(gbcpu);
 	uint8_t old = gbcpu->regs.rn.a;
@@ -706,7 +706,7 @@ static void op_add_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi
 	if (new == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_add_hl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_add_hl(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = (op >> 4) & 3;
 	uint16_t old = REGS16_R(gbcpu->regs, HL);
@@ -728,7 +728,7 @@ static void op_add_hl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->cycles += 4;
 }
 
-static void op_adc(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_adc(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t reg = get_reg(gbcpu, op & 7);
 	uint8_t old = gbcpu->regs.rn.a;
@@ -748,7 +748,7 @@ static void op_adc(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if (gbcpu->regs.rn.a == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_adc_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_adc_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t imm = get_imm8(gbcpu);
 	uint8_t old = gbcpu->regs.rn.a;
@@ -768,7 +768,7 @@ static void op_adc_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi
 	if (gbcpu->regs.rn.a == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_cp(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_cp(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t old = gbcpu->regs.rn.a;
 	uint8_t new = old;
@@ -784,7 +784,7 @@ static void op_cp(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if (new == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_cp_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_cp_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t imm = get_imm8(gbcpu);
 	uint8_t old = gbcpu->regs.rn.a;
@@ -801,7 +801,7 @@ static void op_cp_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if (new == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_sub(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_sub(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t old = gbcpu->regs.rn.a;
 	uint8_t new;
@@ -818,7 +818,7 @@ static void op_sub(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if (new == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_sub_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_sub_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t imm = get_imm8(gbcpu);
 	uint8_t old = gbcpu->regs.rn.a;
@@ -836,7 +836,7 @@ static void op_sub_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi
 	if (new == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_sbc(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_sbc(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t reg = get_reg(gbcpu, op & 7);
 	uint8_t old = gbcpu->regs.rn.a;
@@ -856,7 +856,7 @@ static void op_sbc(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if (gbcpu->regs.rn.a == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_sbc_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_sbc_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t imm = get_imm8(gbcpu);
 	uint8_t old = gbcpu->regs.rn.a;
@@ -876,7 +876,7 @@ static void op_sbc_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi
 	if (gbcpu->regs.rn.a == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_and(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_and(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(oi);
 
@@ -887,7 +887,7 @@ static void op_and(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if (gbcpu->regs.rn.a == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_and_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_and_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t imm = get_imm8(gbcpu);
 
@@ -900,7 +900,7 @@ static void op_and_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi
 	if (gbcpu->regs.rn.a == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_or(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_or(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(oi);
 
@@ -911,7 +911,7 @@ static void op_or(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if (gbcpu->regs.rn.a == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_or_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_or_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t imm = get_imm8(gbcpu);
 
@@ -924,7 +924,7 @@ static void op_or_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if (gbcpu->regs.rn.a == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_xor(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_xor(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(oi);
 
@@ -935,7 +935,7 @@ static void op_xor(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	if (gbcpu->regs.rn.a == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_xor_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_xor_imm(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint8_t imm = get_imm8(gbcpu);
 
@@ -948,7 +948,7 @@ static void op_xor_imm(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi
 	if (gbcpu->regs.rn.a == 0) gbcpu->regs.rn.f |= ZF;
 }
 
-static void op_push(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_push(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = op >> 4 & 3;
 
@@ -960,7 +960,7 @@ static void op_push(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	DPRINTF(" \t%s %s\t", oi->name, regnamech16[reg]);
 }
 
-static void op_push_af(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_push_af(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint16_t tmp = gbcpu->regs.rn.a << 8;
 
@@ -974,7 +974,7 @@ static void op_push_af(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi
 	DPRINTF(" \t%s %s\t", oi->name, regnamech16[op >> 4 & 3]);
 }
 
-static void op_pop(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_pop(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long reg = op >> 4 & 3;
 
@@ -984,7 +984,7 @@ static void op_pop(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	DPRINTF(" \t%s %s\t", oi->name, regnamech16[reg]);
 }
 
-static void op_pop_af(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_pop_af(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint16_t tmp = pop(gbcpu);
 
@@ -996,7 +996,7 @@ static void op_pop_af(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	DPRINTF(" \t%s %s\t", oi->name, regnamech16[op >> 4 & 3]);
 }
 
-static void op_cpl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_cpl(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(op);
 	UNUSED(oi);
@@ -1006,7 +1006,7 @@ static void op_cpl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->regs.rn.f |= NF | HF;
 }
 
-static void op_ccf(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ccf(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(op);
 	UNUSED(oi);
@@ -1016,7 +1016,7 @@ static void op_ccf(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->regs.rn.f &= ~(NF | HF);
 }
 
-static void op_scf(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_scf(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(op);
 	UNUSED(oi);
@@ -1026,7 +1026,7 @@ static void op_scf(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->regs.rn.f &= ~(NF | HF);
 }
 
-static void op_call(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_call(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint16_t ofs = get_imm16(gbcpu);
 
@@ -1040,7 +1040,7 @@ static void op_call(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->cycles += 4;
 }
 
-static void op_call_cond(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_call_cond(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint16_t ofs = get_imm16(gbcpu);
 	long cond = (op >> 3) & 3;
@@ -1060,7 +1060,7 @@ static void op_call_cond(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *
 	REGS16_W(gbcpu->regs, PC, ofs);
 }
 
-static void op_ret(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ret(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(op);
 	UNUSED(oi);
@@ -1071,7 +1071,7 @@ static void op_ret(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	DPRINTF(" \t%s", oi->name);
 }
 
-static void op_reti(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_reti(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(op);
 	UNUSED(oi);
@@ -1083,7 +1083,7 @@ static void op_reti(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->cycles += 4;
 }
 
-static void op_ret_cond(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ret_cond(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long cond = (op >> 3) & 3;
 
@@ -1103,7 +1103,7 @@ static void op_ret_cond(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *o
 	REGS16_W(gbcpu->regs, PC, pop(gbcpu));
 }
 
-static void op_halt(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_halt(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(op);
 	UNUSED(oi);
@@ -1112,7 +1112,7 @@ static void op_halt(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	DPRINTF(" \t%s", oi->name);
 }
 
-static void op_stop(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_stop(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(gbcpu);
 	UNUSED(op);
@@ -1121,7 +1121,7 @@ static void op_stop(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	DPRINTF(" \t%s", oi->name);
 }
 
-static void op_di(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_di(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(op);
 	UNUSED(oi);
@@ -1130,7 +1130,7 @@ static void op_di(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	DPRINTF(" \t%s", oi->name);
 }
 
-static void op_ei(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_ei(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(op);
 	UNUSED(oi);
@@ -1139,7 +1139,7 @@ static void op_ei(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	DPRINTF(" \t%s", oi->name);
 }
 
-static void op_jr(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_jr(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	int16_t ofs = (int8_t) get_imm8(gbcpu);
 
@@ -1157,7 +1157,7 @@ static void op_jr(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	REGS16_W(gbcpu->regs, PC, REGS16_R(gbcpu->regs, PC) + ofs);
 }
 
-static void op_jr_cond(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_jr_cond(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	int16_t ofs = (int8_t) get_imm8(gbcpu);
 	long cond = (op >> 3) & 3;
@@ -1177,7 +1177,7 @@ static void op_jr_cond(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi
 	REGS16_W(gbcpu->regs, PC, REGS16_R(gbcpu->regs, PC) + ofs);
 }
 
-static void op_jp(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_jp(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint16_t ofs = get_imm16(gbcpu);
 
@@ -1190,7 +1190,7 @@ static void op_jp(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	REGS16_W(gbcpu->regs, PC, ofs);
 }
 
-static void op_jp_hl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_jp_hl(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(op);
 	UNUSED(oi);
@@ -1199,7 +1199,7 @@ static void op_jp_hl(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	REGS16_W(gbcpu->regs, PC, REGS16_R(gbcpu->regs, HL));
 }
 
-static void op_jp_cond(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_jp_cond(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	uint16_t ofs = get_imm16(gbcpu);
 	long cond = (op >> 3) & 3;
@@ -1218,7 +1218,7 @@ static void op_jp_cond(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi
 	REGS16_W(gbcpu->regs, PC, ofs);
 }
 
-static void op_rst(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_rst(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	int16_t ofs = op & 0x38;
 
@@ -1231,7 +1231,7 @@ static void op_rst(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	gbcpu->cycles += 4;
 }
 
-static void op_nop(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_nop(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	UNUSED(gbcpu);
 	UNUSED(op);
@@ -1240,7 +1240,7 @@ static void op_nop(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
 	DPRINTF(" \t%s", oi->name);
 }
 
-static void op_daa(struct gbcpu *gbcpu, uint32_t op, const struct opinfo *oi)
+static void op_daa(struct gbcpu* const gbcpu, uint32_t op, const struct opinfo *oi)
 {
 	long a = gbcpu->regs.rn.a;
 	long f = gbcpu->regs.rn.f;
@@ -1534,7 +1534,7 @@ static const struct opinfo ops[256] = {
 };
 
 #if DEBUG == 1
-static void dump_regs(struct gbcpu *gbcpu)
+static void dump_regs(struct gbcpu* const gbcpu)
 {
 	long i;
 
@@ -1549,7 +1549,7 @@ static void dump_regs(struct gbcpu *gbcpu)
 	gbcpu->oldregs = gbcpu->regs;
 }
 
-static void show_reg_diffs(struct gbcpu *gbcpu, const struct opinfo *oi)
+static void show_reg_diffs(struct gbcpu* const gbcpu, const struct opinfo *oi)
 {
 	long i;
 
@@ -1592,7 +1592,7 @@ static void show_reg_diffs(struct gbcpu *gbcpu, const struct opinfo *oi)
 }
 #endif
 
-void gbcpu_add_mem(struct gbcpu *gbcpu, uint32_t start, uint32_t end, gbcpu_put_fn putfn, gbcpu_get_fn getfn, void *priv)
+void gbcpu_add_mem(struct gbcpu* const gbcpu, uint32_t start, uint32_t end, gbcpu_put_fn putfn, gbcpu_get_fn getfn, void *priv)
 {
 	uint32_t i;
 
@@ -1604,7 +1604,7 @@ void gbcpu_add_mem(struct gbcpu *gbcpu, uint32_t start, uint32_t end, gbcpu_put_
 	}
 }
 
-void gbcpu_init(struct gbcpu *gbcpu)
+void gbcpu_init(struct gbcpu* const gbcpu)
 {
 	assert(sizeof(gbcpu->regs) == sizeof(gbcpu_regs_u));
 	memset(&gbcpu->regs, 0, sizeof(gbcpu->regs));
@@ -1615,7 +1615,7 @@ void gbcpu_init(struct gbcpu *gbcpu)
 	DEB(dump_regs(gbcpu));
 }
 
-void gbcpu_intr(struct gbcpu *gbcpu, long vec)
+void gbcpu_intr(struct gbcpu* const gbcpu, long vec)
 {
 	DPRINTF("gbcpu_intr(%04lx)\n", vec);
 	gbcpu->halted = 0;
@@ -1624,7 +1624,7 @@ void gbcpu_intr(struct gbcpu *gbcpu, long vec)
 	REGS16_W(gbcpu->regs, PC, vec);
 }
 
-long gbcpu_step(struct gbcpu *gbcpu)
+long gbcpu_step(struct gbcpu* const gbcpu)
 {
 	uint8_t op;
 

--- a/gbcpu.h
+++ b/gbcpu.h
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2020 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2003-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *                  Christian Garbs <mitch@cgarbs.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
@@ -139,12 +139,12 @@ struct gbcpu {
 	struct put_entry putlookup[GBCPU_LOOKUP_SIZE];
 };
 
-void gbcpu_add_mem(struct gbcpu *gbcpu, uint32_t start, uint32_t end, gbcpu_put_fn putfn, gbcpu_get_fn getfn, void *priv);
-void gbcpu_init(struct gbcpu *gbcpu);
-void gbcpu_init_struct(struct gbcpu *gbcpu);
-long gbcpu_step(struct gbcpu *gbcpu);
-void gbcpu_intr(struct gbcpu *gbcpu, long vec);
-uint8_t gbcpu_mem_get(struct gbcpu *gbcpu, uint16_t addr);
-void gbcpu_mem_put(struct gbcpu *gbcpu, uint16_t addr, uint8_t val);
+void gbcpu_add_mem(struct gbcpu* const gbcpu, uint32_t start, uint32_t end, gbcpu_put_fn putfn, gbcpu_get_fn getfn, void *priv);
+void gbcpu_init(struct gbcpu* const gbcpu);
+void gbcpu_init_struct(struct gbcpu* const gbcpu);
+long gbcpu_step(struct gbcpu* const gbcpu);
+void gbcpu_intr(struct gbcpu* const gbcpu, long vec);
+uint8_t gbcpu_mem_get(struct gbcpu* const gbcpu, uint16_t addr);
+void gbcpu_mem_put(struct gbcpu* const gbcpu, uint16_t addr, uint8_t val);
 
 #endif

--- a/gbhw.c
+++ b/gbhw.c
@@ -617,7 +617,7 @@ static void sequencer_step(struct gbhw *gbhw)
 	}
 }
 
-void gbhw_master_fade(struct gbhw *gbhw, long speed, long dstvol)
+void gbhw_master_fade(struct gbhw* const gbhw, long speed, long dstvol)
 {
 	if (dstvol < MASTER_VOL_MIN) dstvol = MASTER_VOL_MIN;
 	if (dstvol > MASTER_VOL_MAX) dstvol = MASTER_VOL_MAX;
@@ -834,7 +834,7 @@ static void gbhw_impbuf_reset(struct gbhw *gbhw)
 	memset(gbhw->impbuf->data, 0, gbhw->impbuf->bytes);
 }
 
-void gbhw_set_buffer(struct gbhw *gbhw, struct gbhw_buffer *buffer)
+void gbhw_set_buffer(struct gbhw* const gbhw, struct gbhw_buffer *buffer)
 {
 	gbhw->soundbuf = buffer;
 	gbhw->soundbuf->samples = gbhw->soundbuf->bytes / 4;
@@ -858,7 +858,7 @@ static void gbhw_update_filter(struct gbhw *gbhw)
 	gbhw->cap_factor = round(65536.0 * cap_constant);
 }
 
-long gbhw_set_filter(struct gbhw *gbhw, enum gbs_filter_type type)
+long gbhw_set_filter(struct gbhw* const gbhw, enum gbs_filter_type type)
 {
 	switch (type) {
 	case FILTER_OFF:
@@ -885,14 +885,14 @@ long gbhw_set_filter(struct gbhw *gbhw, enum gbs_filter_type type)
 	return 1;
 }
 
-void gbhw_set_rate(struct gbhw *gbhw, long rate)
+void gbhw_set_rate(struct gbhw* const gbhw, long rate)
 {
 	gbhw->sample_rate = rate;
 	gbhw->sound_div_tc = GBHW_CLOCK*SOUND_DIV_MULT/rate;
 	gbhw_update_filter(gbhw);
 }
 
-void gbhw_calc_minmax(struct gbhw *gbhw, int16_t *lmin, int16_t *lmax, int16_t *rmin, int16_t *rmax)
+void gbhw_calc_minmax(struct gbhw* const gbhw, int16_t *lmin, int16_t *lmax, int16_t *rmin, int16_t *rmax)
 {
 	if (gbhw->lminval == INT_MAX) return;
 	*lmin = gbhw->lminval;
@@ -909,7 +909,7 @@ void gbhw_calc_minmax(struct gbhw *gbhw, int16_t *lmin, int16_t *lmax, int16_t *
  * so we don't need range checking in rom_get and
  * rombank_get.
  */
-void gbhw_init(struct gbhw *gbhw)
+void gbhw_init(struct gbhw* const gbhw)
 {
 	long i;
 
@@ -951,12 +951,12 @@ void gbhw_init(struct gbhw *gbhw)
 	gbcpu_add_mem(&gbhw->gbcpu, 0xff, 0xff, io_put, io_get, gbhw);
 }
 
-void gbhw_cleanup(struct gbhw *gbhw)
+void gbhw_cleanup(struct gbhw* const gbhw)
 {
 	if (gbhw->impbuf) free(gbhw->impbuf);
 }
 
-void gbhw_enable_bootrom(struct gbhw *gbhw, const uint8_t *rombuf)
+void gbhw_enable_bootrom(struct gbhw* const gbhw, const uint8_t *rombuf)
 {
 	memcpy(gbhw->boot_rom, rombuf, sizeof(gbhw->boot_rom));
 	gbhw->rom_lockout = 0;
@@ -966,14 +966,14 @@ void gbhw_enable_bootrom(struct gbhw *gbhw, const uint8_t *rombuf)
 }
 
 /* internal for gbs.c, not exported from libgbs */
-void gbhw_io_put(struct gbhw *gbhw, uint16_t addr, uint8_t val) {
+void gbhw_io_put(struct gbhw* const gbhw, uint16_t addr, uint8_t val) {
 	if (addr != 0xffff && (addr < 0xff00 || addr > 0xff7f))
 		return;
 	io_put(gbhw, addr, val);
 }
 
 /* unmasked peek used by gbsplay.c to print regs */
-uint8_t gbhw_io_peek(struct gbhw *gbhw, uint16_t addr)
+uint8_t gbhw_io_peek(const struct gbhw* const gbhw, uint16_t addr)
 {
 	if (addr >= 0xff10 && addr <= 0xff3f) {
 		return gbhw->ioregs[addr & GBHW_IOREGS_MASK];

--- a/gbhw.h
+++ b/gbhw.h
@@ -129,20 +129,20 @@ struct gbhw {
 	struct put_entry boot_shadow_put;
 };
 
-void gbhw_set_callback(struct gbhw *gbhw, gbhw_callback_fn fn, void *priv);
-void gbhw_set_io_callback(struct gbhw *gbhw, gbhw_iocallback_fn fn, void *priv);
-void gbhw_set_step_callback(struct gbhw *gbhw, gbhw_stepcallback_fn fn, void *priv);
-long gbhw_set_filter(struct gbhw *gbhw, enum gbs_filter_type type);
-void gbhw_set_rate(struct gbhw *gbhw, long rate);
-void gbhw_set_buffer(struct gbhw *gbhw, struct gbhw_buffer *buffer);
-void gbhw_init(struct gbhw *gbhw);
-void gbhw_init_struct(struct gbhw *gbhw);
-void gbhw_cleanup(struct gbhw *gbhw);
-void gbhw_enable_bootrom(struct gbhw *gbhw, const uint8_t *rombuf);
-void gbhw_master_fade(struct gbhw *gbhw, long speed, long dstvol);
-void gbhw_calc_minmax(struct gbhw *gbhw, int16_t *lmin, int16_t *lmax, int16_t *rmin, int16_t *rmax);
-long gbhw_step(struct gbhw *gbhw, long time_to_work);
-uint8_t gbhw_io_peek(struct gbhw *gbhw, uint16_t addr);  /* unmasked peek */
-void gbhw_io_put(struct gbhw *gbhw, uint16_t addr, uint8_t val);
+void gbhw_set_callback(struct gbhw* const gbhw, gbhw_callback_fn fn, void *priv);
+void gbhw_set_io_callback(struct gbhw* const gbhw, gbhw_iocallback_fn fn, void *priv);
+void gbhw_set_step_callback(struct gbhw* const gbhw, gbhw_stepcallback_fn fn, void *priv);
+long gbhw_set_filter(struct gbhw* const gbhw, enum gbs_filter_type type);
+void gbhw_set_rate(struct gbhw* const gbhw, long rate);
+void gbhw_set_buffer(struct gbhw* const gbhw, struct gbhw_buffer *buffer);
+void gbhw_init(struct gbhw* const gbhw);
+void gbhw_init_struct(struct gbhw* const gbhw);
+void gbhw_cleanup(struct gbhw* const gbhw);
+void gbhw_enable_bootrom(struct gbhw* const gbhw, const uint8_t *rombuf);
+void gbhw_master_fade(struct gbhw* const gbhw, long speed, long dstvol);
+void gbhw_calc_minmax(struct gbhw* const gbhw, int16_t *lmin, int16_t *lmax, int16_t *rmin, int16_t *rmax);
+long gbhw_step(struct gbhw* const gbhw, long time_to_work);
+uint8_t gbhw_io_peek(const struct gbhw* const gbhw, uint16_t addr);  /* unmasked peek */
+void gbhw_io_put(struct gbhw* const gbhw, uint16_t addr, uint8_t val);
 
 #endif

--- a/gbs.c
+++ b/gbs.c
@@ -105,7 +105,7 @@ struct gbs {
 	struct mapper *mapper;
 };
 
-const struct gbs_metadata *gbs_get_metadata(struct gbs *gbs)
+const struct gbs_metadata *gbs_get_metadata(struct gbs* const gbs)
 {
 	gbs->metadata.title = gbs->title;
 	gbs->metadata.author = gbs->author;
@@ -113,9 +113,9 @@ const struct gbs_metadata *gbs_get_metadata(struct gbs *gbs)
 	return &gbs->metadata;
 }
 
-static void update_status_on_subsong_change(struct gbs *gbs);
+static void update_status_on_subsong_change(struct gbs* const gbs);
 
-void gbs_configure(struct gbs *gbs, long subsong, long subsong_timeout, long silence_timeout, long subsong_gap, long fadeout)
+void gbs_configure(struct gbs* const gbs, long subsong, long subsong_timeout, long silence_timeout, long subsong_gap, long fadeout)
 {
 	gbs->subsong = subsong;
 	gbs->subsong_timeout = subsong_timeout;
@@ -124,14 +124,14 @@ void gbs_configure(struct gbs *gbs, long subsong, long subsong_timeout, long sil
 	gbs->fadeout = fadeout;
 }
 
-void gbs_configure_channels(struct gbs *gbs, long mute_0, long mute_1, long mute_2, long mute_3) {
+void gbs_configure_channels(struct gbs* const gbs, long mute_0, long mute_1, long mute_2, long mute_3) {
 	gbs->gbhw.ch[0].mute = mute_0;
 	gbs->gbhw.ch[1].mute = mute_1;
 	gbs->gbhw.ch[2].mute = mute_2;
 	gbs->gbhw.ch[3].mute = mute_3;
 }
 
-void gbs_configure_output(struct gbs *gbs, struct gbs_output_buffer *gbs_buf, long rate) {
+void gbs_configure_output(struct gbs* const gbs, struct gbs_output_buffer *gbs_buf, long rate) {
 	struct gbhw_buffer *gbhw_buf = &gbs->gbhw_buf;
 
 	gbhw_set_rate(&gbs->gbhw, rate);
@@ -145,7 +145,7 @@ void gbs_configure_output(struct gbs *gbs, struct gbs_output_buffer *gbs_buf, lo
 	gbhw_set_buffer(&gbs->gbhw, gbhw_buf);
 }
 
-long gbs_init(struct gbs *gbs, long subsong)
+long gbs_init(struct gbs* const gbs, long subsong)
 {
 	struct gbhw *gbhw = &gbs->gbhw;
 	struct gbcpu *gbcpu = &gbhw->gbcpu;
@@ -189,7 +189,7 @@ long gbs_init(struct gbs *gbs, long subsong)
 }
 
 // FIXME: or just include a *ptr to the whole RAM in struct gbs_status?
-uint8_t gbs_io_peek(struct gbs *gbs, uint16_t addr) {
+uint8_t gbs_io_peek(const struct gbs* const gbs, uint16_t addr) {
 	return gbhw_io_peek(&gbs->gbhw, addr);
 }
 
@@ -219,7 +219,7 @@ static void map_channel_status(const struct gbhw_channel from[], struct gbs_chan
 	}
 }
 
-void gbs_set_nextsubsong_cb(struct gbs *gbs, gbs_nextsubsong_cb cb, void *priv)
+void gbs_set_nextsubsong_cb(struct gbs* const gbs, gbs_nextsubsong_cb cb, void *priv)
 {
 	gbs->nextsubsong_cb = cb;
 	gbs->nextsubsong_cb_priv = priv;
@@ -231,7 +231,7 @@ static void wrap_io_callback(long cycles, uint32_t addr, uint8_t value, void *pr
 	gbs->io_cb(gbs, cycles, addr, value, gbs->io_cb_priv);
 }
 
-void gbs_set_io_callback(struct gbs *gbs, gbs_io_cb fn, void *priv)
+void gbs_set_io_callback(struct gbs* const gbs, gbs_io_cb fn, void *priv)
 {
 	gbs->io_cb = fn;
 	gbs->io_cb_priv = priv;
@@ -240,12 +240,12 @@ void gbs_set_io_callback(struct gbs *gbs, gbs_io_cb fn, void *priv)
 
 static void wrap_step_callback(const long cycles, const struct gbhw_channel ch[], void *priv)
 {
-	struct gbs *gbs = priv;
+	struct gbs* gbs = priv;
 	map_channel_status(ch, gbs->step_cb_channels);
 	gbs->step_cb(gbs, cycles, gbs->step_cb_channels, gbs->step_cb_priv);
 }
 
-void gbs_set_step_callback(struct gbs *gbs, gbs_step_cb fn, void *priv)
+void gbs_set_step_callback(struct gbs* const gbs, gbs_step_cb fn, void *priv)
 {
 	gbs->step_cb = fn;
 	gbs->step_cb_priv = priv;
@@ -254,23 +254,23 @@ void gbs_set_step_callback(struct gbs *gbs, gbs_step_cb fn, void *priv)
 
 static void wrap_sound_callback(void *priv)
 {
-	struct gbs *gbs = priv;
+	struct gbs* gbs = priv;
 	gbs->buffer->pos = gbs->gbhw_buf.pos;
 	gbs->sound_cb(gbs, gbs->buffer, gbs->sound_cb_priv);
 }
 
-void gbs_set_sound_callback(struct gbs *gbs, gbs_sound_cb fn, void *priv)
+void gbs_set_sound_callback(struct gbs* const gbs, gbs_sound_cb fn, void *priv)
 {
 	gbs->sound_cb = fn;
 	gbs->sound_cb_priv = priv;
 	gbhw_set_callback(&gbs->gbhw, wrap_sound_callback, gbs);
 }
 
-long gbs_set_filter(struct gbs *gbs, enum gbs_filter_type type) {
+long gbs_set_filter(struct gbs* const gbs, enum gbs_filter_type type) {
 	return gbhw_set_filter(&gbs->gbhw, type);
 }
 
-static long gbs_nextsubsong(struct gbs *gbs)
+static long gbs_nextsubsong(struct gbs* const gbs)
 {
 	if (gbs->nextsubsong_cb != NULL) {
 		return gbs->nextsubsong_cb(gbs, gbs->nextsubsong_cb_priv);
@@ -283,7 +283,7 @@ static long gbs_nextsubsong(struct gbs *gbs)
 	return true;
 }
 
-long gbs_step(struct gbs *gbs, long time_to_work)
+long gbs_step(struct gbs* const gbs, long time_to_work)
 {
 	struct gbhw *gbhw = &gbs->gbhw;
 
@@ -328,7 +328,7 @@ long gbs_step(struct gbs *gbs, long time_to_work)
 	return true;
 }
 
-void gbs_print_info(struct gbs *gbs, long verbose)
+void gbs_print_info(const struct gbs* const gbs, long verbose)
 {
 	printf(_("GBSVersion:       %u\n"
 	         "Title:            \"%s\"\n"
@@ -372,7 +372,7 @@ void gbs_print_info(struct gbs *gbs, long verbose)
 	printf(_("CRC32:            0x%08lx\n"), (unsigned long)gbs->crcnow);
 }
 
-static void update_status_on_subsong_change(struct gbs *gbs) {
+static void update_status_on_subsong_change(struct gbs* const gbs) {
 	struct gbs_status *status = &gbs->status;
 
 	status->songtitle = gbs->subsong_info[gbs->subsong].title;
@@ -383,10 +383,10 @@ static void update_status_on_subsong_change(struct gbs *gbs) {
 	status->subsong_len = gbs->subsong_info[gbs->subsong].len;
 }
 
-const struct gbs_status* gbs_get_status(struct gbs *gbs) {
+const struct gbs_status* gbs_get_status(struct gbs* const gbs) {
 
 	struct gbs_status *status = &gbs->status;
-	struct gbhw *gbhw = &gbs->gbhw;
+	const struct gbhw *gbhw = &gbs->gbhw;
 
 	status->rvol = gbs->rvol;
 	status->lvol = gbs->lvol;
@@ -397,11 +397,11 @@ const struct gbs_status* gbs_get_status(struct gbs *gbs) {
 	return status;
 }
 
-long gbs_toggle_mute(struct gbs *gbs, long channel) {
+long gbs_toggle_mute(struct gbs* const gbs, long channel) {
 	return gbs->gbhw.ch[channel].mute ^= 1;
 }
 
-static void gbs_free(struct gbs *gbs)
+static void gbs_free(struct gbs* const gbs)
 {
 	gbhw_cleanup(&gbs->gbhw);
 	if (gbs->mapper)
@@ -415,12 +415,12 @@ static void gbs_free(struct gbs *gbs)
 	free(gbs);
 }
 
-void gbs_close(struct gbs *gbs)
+void gbs_close(struct gbs* const gbs)
 {
 	gbs_free(gbs);
 }
 
-static uint32_t readint(char *buf, long bytes)
+static uint32_t readint(const char* const buf, long bytes)
 {
 	long i;
 	long shift = 0;
@@ -434,7 +434,7 @@ static uint32_t readint(char *buf, long bytes)
 	return res;
 }
 
-long gbs_write(struct gbs *gbs, char *name)
+long gbs_write(const struct gbs* const gbs, const char* const name)
 {
 	long fd;
 	char pad[16];
@@ -465,7 +465,7 @@ long gbs_write(struct gbs *gbs, char *name)
 	return 1;
 }
 
-void gbs_write_rom(struct gbs *gbs, FILE *out, const uint8_t *logo_data)
+void gbs_write_rom(const struct gbs* const gbs, FILE *out, const uint8_t* const logo_data)
 {
 	if (gbs->rom[0x104] != 0xce) {
 		unsigned long tmp = gbs->romsize;
@@ -494,9 +494,9 @@ void gbs_write_rom(struct gbs *gbs, FILE *out, const uint8_t *logo_data)
 	fwrite(gbs->rom, 1, gbs->romsize, out);
 }
 
-static struct gbs *gbs_new(char *buf)
+static struct gbs* gbs_new(char *buf)
 {
-	struct gbs *gbs = calloc(sizeof(struct gbs), 1);
+	struct gbs* gbs = calloc(sizeof(struct gbs), 1);
 	gbhw_init_struct(&gbs->gbhw);
 	gbs->silence_timeout = 2*60;
 	gbs->subsong_timeout = 2*60;
@@ -536,10 +536,10 @@ const uint8_t *gbs_get_bootrom()
 	return bootrom;
 }
 
-static struct gbs *gb_open(const char *name, char *buf, size_t size)
+static struct gbs *gb_open(const char* const name, char *buf, size_t size)
 {
 	long i;
-	struct gbs *gbs = gbs_new(buf);
+	struct gbs* gbs = gbs_new(buf);
 	char *na_str = _("gb / not available");
 	const uint8_t *bootrom = gbs_get_bootrom();
 
@@ -585,10 +585,10 @@ static struct gbs *gb_open(const char *name, char *buf, size_t size)
 	return gbs;
 }
 
-static struct gbs *gbr_open(const char *name, char *buf, size_t size)
+static struct gbs *gbr_open(const char* const name, char *buf, size_t size)
 {
 	long i;
-	struct gbs *gbs = gbs_new(buf);
+	struct gbs* gbs = gbs_new(buf);
 	char *na_str = _("gbr / not available");
 	uint16_t vsync_addr;
 	uint16_t timer_addr;
@@ -663,19 +663,19 @@ static struct gbs *gbr_open(const char *name, char *buf, size_t size)
 	return gbs;
 }
 
-static uint32_t le32(const char *buf)
+static uint32_t le32(const char* const buf)
 {
 	const uint8_t *b = (const uint8_t*)buf;
 	return b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24);
 }
 
-static uint16_t le16(const char *buf)
+static uint16_t le16(const char* const buf)
 {
 	const uint8_t *b = (const uint8_t*)buf;
 	return b[0] | (b[1] << 8);
 }
 
-static void emit(struct gbs *gbs, long *code_used, uint8_t data, long reserve)
+static void emit(struct gbs* const gbs, long* const code_used, uint8_t data, long reserve)
 {
 	long remain = gbs->codelen - *code_used;
 	uint8_t *code = (uint8_t*) &gbs->code[*code_used];
@@ -692,7 +692,7 @@ static void emit(struct gbs *gbs, long *code_used, uint8_t data, long reserve)
 	(*code_used)++;
 }
 
-static void gd3_parse(struct gbs **gbs, const char *gd3, long gd3_len)
+static void gd3_parse(struct gbs **gbs, const char* const gd3, long gd3_len)
 {
 	char *buf;
 	char *s;
@@ -733,9 +733,9 @@ static void gd3_parse(struct gbs **gbs, const char *gd3, long gd3_len)
 	}
 }
 
-static struct gbs *vgm_open(const char *name, char *buf, size_t size)
+static struct gbs *vgm_open(const char* const name, char* const buf, size_t size)
 {
-	struct gbs *gbs = gbs_new(buf);
+	struct gbs* gbs = gbs_new(buf);
 	char *na_str = _("vgm / not available");
 	char *gd3 = NULL;
 	char *data;
@@ -955,9 +955,9 @@ static struct gbs *vgm_open(const char *name, char *buf, size_t size)
 	return gbs;
 }
 
-static struct gbs *gbs_open_internal(const char *name, char *buf, size_t size)
+static struct gbs* gbs_open_internal(const char* const name, char* const buf, size_t size)
 {
-	struct gbs *gbs = gbs_new(buf);
+	struct gbs* const gbs = gbs_new(buf);
 	long i, addr, jpaddr;
 
 	UNUSED(name);
@@ -1105,12 +1105,12 @@ static struct gbs *gbs_open_internal(const char *name, char *buf, size_t size)
 	return gbs;
 }
 
-static struct gbs *gbs_open_mem(const char *name, char *buf, size_t size);
+static struct gbs* gbs_open_mem(const char* const name, char* const buf, size_t size);
 
 #ifdef USE_ZLIB
-static struct gbs *gzip_open(const char *name, char *buf, size_t size)
+static struct gbs *gzip_open(const char* const name, char* const buf, size_t size)
 {
-	struct gbs *gbs;
+	struct gbs* gbs;
 	int ret;
 	char *out = malloc(GB_MAX_ROM_SIZE);
 	z_stream strm;
@@ -1144,14 +1144,14 @@ static struct gbs *gzip_open(const char *name, char *buf, size_t size)
 	return gbs;
 }
 #else
-static struct gbs *gzip_open(const char *name, char *buf, size_t size)
+static struct gbs *gzip_open(const char* const name, char* const buf, size_t size)
 {
 	fprintf(stderr, _("Could not open %s: %s\n"), name, _("Not compiled with zlib support"));
 	return NULL;
 }
 #endif
 
-static struct gbs *gbs_open_mem(const char *name, char *buf, size_t size)
+static struct gbs* gbs_open_mem(const char* const name, char* const buf, size_t size)
 {
 	if (size > HDR_LEN_GZIP && strncmp(buf, GZIP_MAGIC, 3) == 0) {
 		return gzip_open(name, buf, size);
@@ -1172,9 +1172,9 @@ static struct gbs *gbs_open_mem(const char *name, char *buf, size_t size)
 	return NULL;
 }
 
-struct gbs *gbs_open(const char *name)
+struct gbs* gbs_open(const char* const name)
 {
-	struct gbs *gbs = NULL;
+	struct gbs* gbs = NULL;
 	FILE *f;
 	struct stat st;
 	char *buf;

--- a/gbs2gb.c
+++ b/gbs2gb.c
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2020 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2003-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *                  Christian Garbs <mitch@cgarbs.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
@@ -40,7 +40,7 @@ void version(void)
 	exit(EXIT_SUCCESS);
 }
 
-void read_rom_template(const char *name)
+void read_rom_template(const char* const name)
 {
 	FILE *f = fopen(name, "rb");
 	uint8_t hdr[0x200];

--- a/gbs_internal.h
+++ b/gbs_internal.h
@@ -21,11 +21,11 @@
  ***/
 
 typedef const uint8_t* (get_bootrom_fn)(void);
-typedef void (write_rom_fn)(struct gbs *gbs, FILE *out, const uint8_t *logo_data);
-typedef void (print_info_fn)(struct gbs *gbs, long verbose);
+typedef void (write_rom_fn)(const struct gbs* const gbs, FILE *out, const uint8_t *logo_data);
+typedef void (print_info_fn)(const struct gbs* const gbs, long verbose);
 
 struct gbs_internal_api {
-	const char *version;
+	const char* version;
 	get_bootrom_fn *get_bootrom;
 	write_rom_fn *write_rom;
 	print_info_fn *print_info;

--- a/libgbs.h
+++ b/libgbs.h
@@ -121,7 +121,7 @@ enum gbs_filter_type {
  * @param value   the value that was writton
  * @param priv    opaque private context pointer for the callback handler
  */
-typedef void (*gbs_io_cb)(struct gbs *gbs, long cycles, uint32_t addr, uint8_t value, void *priv);
+typedef void (*gbs_io_cb)(struct gbs* const gbs, long cycles, uint32_t addr, uint8_t value, void *priv);
 
 /**
  * Step callback.  This callback gets executed after each machine instruction
@@ -133,7 +133,7 @@ typedef void (*gbs_io_cb)(struct gbs *gbs, long cycles, uint32_t addr, uint8_t v
  * @param channels  current status of all 4 channels
  * @param priv      opaque private context pointer for the callback handler
  */
-typedef void (*gbs_step_cb)(struct gbs *gbs, const long cycles, const struct gbs_channel_status channels[], void *priv);
+typedef void (*gbs_step_cb)(struct gbs* const gbs, const long cycles, const struct gbs_channel_status channels[], void *priv);
 
 /**
  * Sound callback.  This callback gets executed when the next part of
@@ -145,7 +145,7 @@ typedef void (*gbs_step_cb)(struct gbs *gbs, const long cycles, const struct gbs
  * @param buf   the output buffer containing the rendered sound
  * @param priv  opaque private context pointer for the callback handler
  */
-typedef void (*gbs_sound_cb)(struct gbs *gbs, struct gbs_output_buffer *buf, void *priv);
+typedef void (*gbs_sound_cb)(struct gbs* const gbs, struct gbs_output_buffer *buf, void *priv);
 
 /**
  * Next subsong callback.  This callback gets executed when the
@@ -159,7 +159,7 @@ typedef void (*gbs_sound_cb)(struct gbs *gbs, struct gbs_output_buffer *buf, voi
  * @param gbs     reference to the gbs instance that executed the IO
  * @param priv    opaque private context pointer for the callback handler
  */
-typedef long (*gbs_nextsubsong_cb)(struct gbs *gbs, void *priv);
+typedef long (*gbs_nextsubsong_cb)(struct gbs* const gbs, void *priv);
 
 //
 //////  functions
@@ -176,23 +176,23 @@ typedef long (*gbs_nextsubsong_cb)(struct gbs *gbs, void *priv);
  * @param name  filename to open (optionally including a path)
  * @return an opaque @link struct gbs @endlink to be passed to other functions or NULL on error
  */
-struct gbs *gbs_open(const char *name);
+struct gbs *gbs_open(const char* const name);
 
-void gbs_configure(struct gbs *gbs, long subsong, long subsong_timeout, long silence_timeout, long subsong_gap, long fadeout);
-void gbs_configure_channels(struct gbs *gbs, long mute_0, long mute_1, long mute_2, long mute_3);
-void gbs_configure_output(struct gbs *gbs, struct gbs_output_buffer *buf, long rate);
-const struct gbs_metadata *gbs_get_metadata(struct gbs *gbs);
-long gbs_init(struct gbs *gbs, long subsong);
-uint8_t gbs_io_peek(struct gbs *gbs, uint16_t addr);
-const struct gbs_status* gbs_get_status(struct gbs *gbs);
-long gbs_step(struct gbs *gbs, long time_to_work);
-void gbs_set_nextsubsong_cb(struct gbs *gbs, gbs_nextsubsong_cb cb, void *priv);
-void gbs_set_io_callback(struct gbs *gbs, gbs_io_cb fn, void *priv);
-void gbs_set_step_callback(struct gbs *gbs, gbs_step_cb fn, void *priv);
-void gbs_set_sound_callback(struct gbs *gbs, gbs_sound_cb fn, void *priv);
-long gbs_set_filter(struct gbs *gbs, enum gbs_filter_type type);
-long gbs_toggle_mute(struct gbs *gbs, long channel);
-void gbs_close(struct gbs *gbs);
-long gbs_write(struct gbs *gbs, char *name);
+void gbs_configure(struct gbs* const gbs, long subsong, long subsong_timeout, long silence_timeout, long subsong_gap, long fadeout);
+void gbs_configure_channels(struct gbs* const gbs, long mute_0, long mute_1, long mute_2, long mute_3);
+void gbs_configure_output(struct gbs* const gbs, struct gbs_output_buffer *buf, long rate);
+const struct gbs_metadata *gbs_get_metadata(struct gbs* const gbs);
+long gbs_init(struct gbs* const gbs, long subsong);
+uint8_t gbs_io_peek(const struct gbs* const gbs, uint16_t addr);
+const struct gbs_status* gbs_get_status(struct gbs* const gbs);
+long gbs_step(struct gbs* const gbs, long time_to_work);
+void gbs_set_nextsubsong_cb(struct gbs* const gbs, gbs_nextsubsong_cb cb, void *priv);
+void gbs_set_io_callback(struct gbs* const gbs, gbs_io_cb fn, void *priv);
+void gbs_set_step_callback(struct gbs* const gbs, gbs_step_cb fn, void *priv);
+void gbs_set_sound_callback(struct gbs* const gbs, gbs_sound_cb fn, void *priv);
+long gbs_set_filter(struct gbs* const gbs, enum gbs_filter_type type);
+long gbs_toggle_mute(struct gbs* const gbs, long channel);
+void gbs_close(struct gbs* const gbs);
+long gbs_write(const struct gbs* const gbs, const char* const name);
 
 #endif

--- a/plugout.c
+++ b/plugout.c
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2003-2020 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2003-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *                  Christian Garbs <mitch@cgarbs.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
@@ -100,7 +100,7 @@ void plugout_list_plugins(void)
 	(void)puts("");
 }
 
-const struct output_plugin* plugout_select_by_name(const char *name)
+const struct output_plugin* plugout_select_by_name(const char* const name)
 {
 	long idx;
 

--- a/plugout.h
+++ b/plugout.h
@@ -1,7 +1,7 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2004-2020 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
+ * 2004-2021 (C) by Tobias Diedrich <ranma+gbsplay@tdiedrich.de>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
  */
@@ -56,6 +56,6 @@ struct output_plugin {
 };
 
 void plugout_list_plugins(void);
-const struct output_plugin* plugout_select_by_name(const char *name);
+const struct output_plugin* plugout_select_by_name(const char* const name);
 
 #endif

--- a/test.h
+++ b/test.h
@@ -54,7 +54,7 @@
 typedef void (*test_fn)(void);
 struct test_entry {
 	test_fn func;
-	const char* name;
+	const char* const name;
 };
 
 #define TEST(func) test_entries struct test_entry test_ ## func = { func, #func }


### PR DESCRIPTION
I've sprinkled lots of `const` over the place.
Is this useful?

I've looked a pointers and there are two types of changes:

1. In far too few places I could switch from `struct bar *foo` to `const struct bar *foo`. This should be OK in all cases.
2. I've also make `struct bar *foo` into `struct bar* const foo`. This seems to be possible nearly everywhere, but is it useful in any way?

I feel unsure if I should just remove part 2 (this would be fast, just search & replace).
Any thoughts?