### PR TITLE
Bugfix/repeat finite subsongs

### DIFF
--- a/gbsplay.c
+++ b/gbsplay.c
@@ -125,7 +125,9 @@ static void handleuserinput(struct gbs *gbs)
 			if (verbosity>1) printstatus(gbs);
 			break;
 		case 'l':
+			//TODO Merge the loop_mode variables so there's one source of truth
 			gbs_cycle_loop_mode(gbs);
+			cycle_loop_mode();
 			break;
 		case '1':
 		case '2':

--- a/gbsplay.c
+++ b/gbsplay.c
@@ -27,6 +27,10 @@ static long quit = 0;
 /* default values */
 long redraw = false;
 
+/* forward declarations */
+static void printstatus(struct gbs *gbs);
+static void printinfo();
+
 static long getnote(long div)
 {
 	long n = 0;
@@ -117,6 +121,8 @@ static void handleuserinput(struct gbs *gbs)
 			break;
 		case ' ':
 			toggle_pause(gbs);
+			if (redraw) printinfo();
+			if (verbosity>1) printstatus(gbs);
 			break;
 		case 'l':
 			gbs_cycle_loop_mode(gbs);
@@ -188,15 +194,17 @@ static void printstatus(struct gbs *gbs)
 {
 	const struct gbs_status *status;
 	struct displaytime time;
+	long pausemode;
 
 	status = gbs_get_status(gbs);
+	pausemode = get_pause();
 
 	update_displaytime(&time, status);
 
 	printf("\r\033[A\033[A"
-	       "Song %3d/%3d%s (%s)\033[K\n"
+	       "Song %3d/%3d%s%s (%s)\033[K\n"
 	       "%02ld:%02ld/%02ld:%02ld",
-	       status->subsong+1, status->songs,
+	       status->subsong+1, status->songs, pausemode ? " [Paused]" : "",
 	       loopmodestring(status), status->songtitle,
 	       time.played_min, time.played_sec, time.total_min, time.total_sec);
 	if (verbosity>2) {

--- a/player.c
+++ b/player.c
@@ -324,6 +324,16 @@ long get_pause()
 	return pause_mode;
 }
 
+void cycle_loop_mode()
+{
+	switch (loop_mode) {
+	default:
+	case LOOP_OFF:    loop_mode = LOOP_RANGE;  break;
+	case LOOP_RANGE:  loop_mode = LOOP_SINGLE; break;
+	case LOOP_SINGLE: loop_mode = LOOP_OFF;    break;
+	}
+}
+
 long step_emulation(struct gbs *gbs) {
 	if (is_running()) {
 		return gbs_step(gbs, refresh_delay);

--- a/player.c
+++ b/player.c
@@ -319,6 +319,11 @@ void toggle_pause()
 		sound_pause(pause_mode);
 }
 
+long get_pause()
+{
+	return pause_mode;
+}
+
 long step_emulation(struct gbs *gbs) {
 	if (is_running()) {
 		return gbs_step(gbs, refresh_delay);

--- a/player.h
+++ b/player.h
@@ -45,6 +45,7 @@ void play_prev_subsong(struct gbs *gbs);
 long step_emulation(struct gbs *gbs);
 void toggle_pause();
 long get_pause();
+void cycle_loop_mode();
 void update_displaytime(struct displaytime *time, const struct gbs_status *status);
 struct gbs *common_init(int argc, char **argv);
 void common_cleanup(struct gbs *gbs);

--- a/player.h
+++ b/player.h
@@ -44,6 +44,7 @@ void play_next_subsong(struct gbs *gbs);
 void play_prev_subsong(struct gbs *gbs);
 long step_emulation(struct gbs *gbs);
 void toggle_pause();
+long get_pause();
 void update_displaytime(struct displaytime *time, const struct gbs_status *status);
 struct gbs *common_init(int argc, char **argv);
 void common_cleanup(struct gbs *gbs);


### PR DESCRIPTION
Finite subsongs - ones that have an actual end, rather than automatically looping - weren't looping right in "LOOP_SINGLE" mode, when initiated by the hotkey.  Somehow we ended up with two places where loop_mode is stored.  While I'd prefer there be only one, I'm not sure how to combine them, so I made the less invasive change of making sure both are updated together when the hotkey is pressed.