### PR TITLE
Clean up and fix MIDI note calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -541,7 +541,7 @@ test: gbsplay $(tests) test_gbs
 	fi
 	$(Q)rm gbsplay-1.vgm
 	$(Q)MD5=`LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH-} $(TEST_WRAPPER) ./gbsplay -c examples/gbsplayrc_sample -E l -o midi $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null; cat gbsplay-1.mid | (md5sum || md5 -r) | cut -f1 -d\ `; \
-	EXPECT="d750af6c0b50a32802fb0bab67b8892f"; \
+	EXPECT="11df5802d1c9e928a4ef584d4f9a99b8"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "MIDI output ok"; \
 	else \
@@ -551,7 +551,7 @@ test: gbsplay $(tests) test_gbs
 		exit 1; \
 	fi
 	$(Q)MD5=`LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH-} $(TEST_WRAPPER) ./gbsplay -c examples/gbsplayrc_sample -E l -o altmidi $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null; cat gbsplay-1.mid | (md5sum || md5 -r) | cut -f1 -d\ `; \
-	EXPECT="d750af6c0b50a32802fb0bab67b8892f"; \
+	EXPECT="801d34a7dfffd4a53991b699da28bc60"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "alternate MIDI output ok"; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -541,7 +541,7 @@ test: gbsplay $(tests) test_gbs
 	fi
 	$(Q)rm gbsplay-1.vgm
 	$(Q)MD5=`LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH-} $(TEST_WRAPPER) ./gbsplay -c examples/gbsplayrc_sample -E l -o midi $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null; cat gbsplay-1.mid | (md5sum || md5 -r) | cut -f1 -d\ `; \
-	EXPECT="11df5802d1c9e928a4ef584d4f9a99b8"; \
+	EXPECT="656c7e54fe25e643ea74b7f1545312ae"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "MIDI output ok"; \
 	else \
@@ -551,7 +551,7 @@ test: gbsplay $(tests) test_gbs
 		exit 1; \
 	fi
 	$(Q)MD5=`LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH-} $(TEST_WRAPPER) ./gbsplay -c examples/gbsplayrc_sample -E l -o altmidi $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null; cat gbsplay-1.mid | (md5sum || md5 -r) | cut -f1 -d\ `; \
-	EXPECT="801d34a7dfffd4a53991b699da28bc60"; \
+	EXPECT="8fcf6be8d6c8a1c7f659c60e1a96db18"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "alternate MIDI output ok"; \
 	else \

--- a/common.h
+++ b/common.h
@@ -48,10 +48,10 @@ typedef uint64_t cycles_t;
 #define TEXTDOMAIN "gbsplay"
 #define N_(x) x
 
-#define LN2 .69314718055994530941
-#define MAGIC 5.78135971352465960412
-#define FREQ(x) (262144 / (x))
-#define NOTE(x) ((long)((log(FREQ(x))/LN2 - MAGIC)*12 + .2))
+#define A1HZ 55.
+#define A1MIDI 33
+#define FREQ(x) (65536. / (x))
+#define NOTE(x) (lround(log2(FREQ(x)/A1HZ)*12)+A1MIDI)
 
 #if USE_I18N == 1
 

--- a/common.h
+++ b/common.h
@@ -50,8 +50,9 @@ typedef uint64_t cycles_t;
 
 #define A1HZ 55.
 #define A1MIDI 33
-#define FREQ(x) (65536. / (x))
-#define NOTE(x) (lround(log2(FREQ(x)/A1HZ)*12)+A1MIDI)
+/* wave channel produces half the frequency */
+#define FREQ(x,c) (131072. / ((x)<<((c)>1)))
+#define NOTE(x,c) (lround(log2(FREQ(x,c)/A1HZ)*12)+A1MIDI)
 
 #if USE_I18N == 1
 

--- a/gbsplay.c
+++ b/gbsplay.c
@@ -31,12 +31,12 @@ long redraw = false;
 static void printstatus(struct gbs *gbs);
 static void printinfo();
 
-static long getnote(long div)
+static long getnote(long div, long ch)
 {
 	long n = 0;
 
 	if (div>0) {
-		n = NOTE(div) - 9;
+		n = NOTE(div, ch);
 	}
 
 	if (n < 0) {
@@ -148,7 +148,7 @@ static char *notestring(const struct gbs_status *status, long ch)
 
 	if (status->ch[ch].vol == 0) return "---";
 
-	n = getnote(status->ch[ch].div_tc);
+	n = getnote(status->ch[ch].div_tc, ch);
 	if (ch != 3) return &notelookup[4*n];
 	else return "nse";
 }

--- a/gbsplay.c
+++ b/gbsplay.c
@@ -36,7 +36,7 @@ static long getnote(long div)
 	long n = 0;
 
 	if (div>0) {
-		n = NOTE(div);
+		n = NOTE(div) - 9;
 	}
 
 	if (n < 0) {

--- a/gbsplay.c
+++ b/gbsplay.c
@@ -55,13 +55,15 @@ static void precalc_notes(void)
 		char *s = notelookup + 4*i;
 		long n = i % 12;
 
-		s[2] = '0' + i / 12;
-		n += (n > 2) + (n > 7);
-		s[0] = 'A' + (n >> 1);
-		if (n & 1) {
+		// lowest possible frequency is 2^17/((2^11-1)*2)Hz,
+		// i.e. C1; far from producing octave '/'
+		s[2] = '0' + i / 12 - 1;
+		n += (n > 4);
+		s[0] = 'A' + (((n >> 1) + 'C' - 'A') % ('H' - 'A'));
+		if (n % 2) {
 			s[1] = '#';
 		} else {
-			s[1] = '-';
+			s[1] = ' ';
 		}
 	}
 }

--- a/plugout_altmidi.c
+++ b/plugout_altmidi.c
@@ -33,7 +33,7 @@ static int midi_step(cycles_t cycles, const struct gbs_channel_status status[])
 
 		if (playing[c]) {
 			if (new_playing) {
-				new_note = NOTE(ch->div_tc);
+				new_note = NOTE(ch->div_tc, c);
 				if (new_note != note[c]) {
 					midi_note_off(cycles, c);
 					if (new_note < 0 || new_note >= 0x80)
@@ -46,7 +46,7 @@ static int midi_step(cycles_t cycles, const struct gbs_channel_status status[])
 			}
 		} else {
 			if (new_playing) {
-				new_note = NOTE(ch->div_tc);
+				new_note = NOTE(ch->div_tc, c);
 				if (new_note < 0 || new_note >= 0x80)
 					continue;
 				midi_note_on(cycles, c, new_note, volume[c]);

--- a/plugout_altmidi.c
+++ b/plugout_altmidi.c
@@ -33,7 +33,7 @@ static int midi_step(cycles_t cycles, const struct gbs_channel_status status[])
 
 		if (playing[c]) {
 			if (new_playing) {
-				new_note = NOTE(ch->div_tc) + 21;
+				new_note = NOTE(ch->div_tc);
 				if (new_note != note[c]) {
 					midi_note_off(cycles, c);
 					if (new_note < 0 || new_note >= 0x80)
@@ -46,7 +46,7 @@ static int midi_step(cycles_t cycles, const struct gbs_channel_status status[])
 			}
 		} else {
 			if (new_playing) {
-				new_note = NOTE(ch->div_tc) + 21;
+				new_note = NOTE(ch->div_tc);
 				if (new_note < 0 || new_note >= 0x80)
 					continue;
 				midi_note_on(cycles, c, new_note, volume[c]);

--- a/plugout_midi.c
+++ b/plugout_midi.c
@@ -41,7 +41,7 @@ static int midi_io(cycles_t cycles, uint32_t addr, uint8_t val)
 		if (volume[chan]) {
 			/* volume set to >0, restart current note */
 			if (running[chan] && !note[chan]) {
-				new_note = NOTE(2048 - div[chan]) + 21;
+				new_note = NOTE(2048 - div[chan]);
 				if (new_note < 0 || new_note >= 0x80)
 					break;
 				midi_note_on(cycles, chan, new_note, volume[chan]);
@@ -58,7 +58,7 @@ static int midi_io(cycles_t cycles, uint32_t addr, uint8_t val)
 		div[chan] |= val;
 
 		if (running[chan]) {
-			new_note = NOTE(2048 - div[chan]) + 21;
+			new_note = NOTE(2048 - div[chan]);
 
 			if (new_note != note[chan]) {
 				/* portamento: retrigger with new note */
@@ -78,7 +78,7 @@ static int midi_io(cycles_t cycles, uint32_t addr, uint8_t val)
 		div[chan] &= 0x00ff;
 		div[chan] |= ((long) (val & 7)) << 8;
 
-		new_note = NOTE(2048 - div[chan]) + 21;
+		new_note = NOTE(2048 - div[chan]);
 
 		/* Channel start trigger */
 		if ((val & 0x80) == 0x80) {
@@ -119,7 +119,7 @@ static int midi_io(cycles_t cycles, uint32_t addr, uint8_t val)
 		if (volume[2]) {
 			/* volume set to >0, restart current note */
 			if (running[2] && !note[2]) {
-				new_note = NOTE(2048 - div[chan]) + 21;
+				new_note = NOTE(2048 - div[chan]);
 				if (new_note < 0 || new_note >= 0x80)
 					break;
 				midi_note_on(cycles, 2, new_note, volume[2]);

--- a/plugout_midi.c
+++ b/plugout_midi.c
@@ -41,7 +41,7 @@ static int midi_io(cycles_t cycles, uint32_t addr, uint8_t val)
 		if (volume[chan]) {
 			/* volume set to >0, restart current note */
 			if (running[chan] && !note[chan]) {
-				new_note = NOTE(2048 - div[chan]);
+				new_note = NOTE(2048 - div[chan], chan);
 				if (new_note < 0 || new_note >= 0x80)
 					break;
 				midi_note_on(cycles, chan, new_note, volume[chan]);
@@ -58,7 +58,7 @@ static int midi_io(cycles_t cycles, uint32_t addr, uint8_t val)
 		div[chan] |= val;
 
 		if (running[chan]) {
-			new_note = NOTE(2048 - div[chan]);
+			new_note = NOTE(2048 - div[chan], chan);
 
 			if (new_note != note[chan]) {
 				/* portamento: retrigger with new note */
@@ -78,7 +78,7 @@ static int midi_io(cycles_t cycles, uint32_t addr, uint8_t val)
 		div[chan] &= 0x00ff;
 		div[chan] |= ((long) (val & 7)) << 8;
 
-		new_note = NOTE(2048 - div[chan]);
+		new_note = NOTE(2048 - div[chan], chan);
 
 		/* Channel start trigger */
 		if ((val & 0x80) == 0x80) {
@@ -119,7 +119,7 @@ static int midi_io(cycles_t cycles, uint32_t addr, uint8_t val)
 		if (volume[2]) {
 			/* volume set to >0, restart current note */
 			if (running[2] && !note[2]) {
-				new_note = NOTE(2048 - div[chan]);
+				new_note = NOTE(2048 - div[chan], chan);
 				if (new_note < 0 || new_note >= 0x80)
 					break;
 				midi_note_on(cycles, 2, new_note, volume[2]);


### PR DESCRIPTION
When I noticed that the note display was off for A, A♯, and B, I tried to fix it and fell into the rabbit hole of that calculation macro, which literally contained `MAGIC`. 😄  Since the `{,alt}midi` plugouts also produced tracks where the wave channel was an octave too high, I reduced that as well and only afterwards found that the other channels were right before. So now the calculation also takes the channel into account.

Let me know if there are still things left unclear.

I'd also like to tackle the noise channel in the near future, since I think it should be possible to map it to percussion events, but for this I'll need to do a little more research.