### PR TITLE
Determine SDL2 lib path in addition to include path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ plugout_ldflags += -laudio $(libaudio_flags)
 endif
 ifeq ($(plugout_sdl),yes)
 plugout_objs += plugout_sdl.o
-plugout_ldflags += -lSDL2
+plugout_ldflags += $(libSDL2_flags)
 endif
 ifeq ($(plugout_stdout),yes)
 plugout_objs += plugout_stdout.o

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ plugout_ldflags += -laudio $(libaudio_flags)
 endif
 ifeq ($(plugout_sdl),yes)
 plugout_objs += plugout_sdl.o
-plugout_ldflags += $(libSDL2_flags)
+plugout_ldflags += -lSDL2 $(libSDL2_flags)
 endif
 ifeq ($(plugout_stdout),yes)
 plugout_objs += plugout_stdout.o

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ plugout_ldflags += -laudio $(libaudio_flags)
 endif
 ifeq ($(plugout_sdl),yes)
 plugout_objs += plugout_sdl.o
-plugout_ldflags += -lSDL2 $(libSDL2_flags)
+plugout_ldflags += $(libSDL2_flags)
 endif
 ifeq ($(plugout_stdout),yes)
 plugout_objs += plugout_stdout.o

--- a/configure
+++ b/configure
@@ -847,14 +847,25 @@ if [ "$use_sdl" != no ]; then
         sdl2_include_path="${sdl2_include_path#*-I}"
         sdl2_include_path="${sdl2_include_path%% -*}"
     else
-        sdl2_include_path='/usr/include/SDL2 /usr/local/include/SDL2 /opt/local/include/SDL2'
+        sdl2_include_path='/usr/include/SDL2 /usr/local/include/SDL2 /opt/local/include/SDL2 /opt/homebrew/include/SDL2'
     fi
-        
+
     check_include SDL.h "$sdl2_include_path" "#define SDL_MAIN_HANDLED"
     if [ "$have_SDL_h" = yes ]; then
         if [ "$include_SDL_h_path" != ' ' ]; then
             append_nodupe CFLAGS "-I$include_SDL_h_path"
         fi
+        if command -v sdl2-config >/dev/null; then
+            sdl2_lib_path="$(sdl2-config --libs)"
+            sdl2_lib_path="${sdl2_lib_path#*-L}"
+            sdl2_lib_path="${sdl2_lib_path%% -*}"
+        else
+            sdl2_lib_path="/usr/lib /usr/local/lib /opt/local/lib /opt/homebrew/lib"
+        fi
+        check_libs SDL2 "" "$sdl2_lib_path" <<EOF
+#include <SDL.h>
+int main(int argc, char **argv) { SDL_Init(0); return 0; }
+EOF
         use_sdl=yes
     fi
 
@@ -1268,6 +1279,7 @@ use_verbosebuild
 windows_build
 windows_libprefix
 libaudio_flags
+libSDL2_flags
 __EOF__
     echo plugout_alsa := $use_alsa
     echo plugout_devdsp := $use_devdsp

--- a/configure
+++ b/configure
@@ -863,10 +863,16 @@ if [ "$use_sdl" != no ]; then
             sdl2_lib_path="/usr/lib /usr/local/lib /opt/local/lib /opt/homebrew/lib"
         fi
         check_libs SDL2 "" "$sdl2_lib_path" <<EOF
+#define SDL_MAIN_HANDLED
 #include <SDL.h>
-int main(int argc, char **argv) { SDL_Init(0); return 0; }
+int main(int argc, char **argv) {
+    SDL_Init(0);
+    return 0;
+}
 EOF
-        use_sdl=yes
+        if [ "$?" -eq 0 ]; then
+            use_sdl=yes
+        fi
     fi
 
     recheck_use sdl


### PR DESCRIPTION
Fixes plugout_sdl build on MacOS (homebrew)

Homebrew stores headers, libs, etc. under an /opt/homebrew prefix.
`configure` currently determines the correct include path but not the lib path.

Use `sdl2-config --libs` and `check_libs()` to determine the lib path as well.
Also add /opt/homebrew/... to the fallback include and lib paths.