### PR TITLE
Fix FreeBSD plugout_devdsp compilation errors

### DIFF
--- a/.github/workflows/build_freebsd.yml
+++ b/.github/workflows/build_freebsd.yml
@@ -36,6 +36,7 @@ jobs:
           CONFIGURE_FLAGS: ${{ matrix.flags }} --enable-verbosebuild
           CFLAGS: -Wformat -Werror=format-security -Wall -pedantic
         with:
+          environment_variables: CONFIGURE_FLAGS CFLAGS
           operating_system: ${{ matrix.os.name }}
           architecture: ${{ matrix.os.architecture }}
           version: ${{ matrix.os.version }}

--- a/.github/workflows/build_freebsd.yml
+++ b/.github/workflows/build_freebsd.yml
@@ -18,15 +18,16 @@ jobs:
     strategy:
       matrix:
         os:
-          - name: freebsd
-            architecture: x86-64
-            version: '13.2'
-            host: macos-12
+#          - name: freebsd
+#            architecture: x86-64
+#            version: '13.2'
+#            host: macos-12
           - name: freebsd
             architecture: arm64
             version: '13.2'
             host: ubuntu-latest
-        flags: ['', '--enable-sharedlibgbs']
+        flags: ['']
+#        flags: ['', '--enable-sharedlibgbs']
 
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +47,7 @@ jobs:
           run: |
             yes | sudo pkg install gmake
             gmake
-            ./check_plugout_wav.sh
+            ## ./check_plugout_wav.sh
       - name: Check activated plugouts
         run: |
           ./check_plugouts.sh devdsp wav

--- a/HISTORY
+++ b/HISTORY
@@ -5,6 +5,11 @@ gbsplay HISTORY
 202x/xx/xx  -  unreleased
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Bugfixes:
+
+- build process:
+  - fix build errors of devdsp plugout on FreeBSD
+
 Enhancements:
 
 - build process:

--- a/configure
+++ b/configure
@@ -762,6 +762,39 @@ if [ "$use_devdsp" != no ]; then
     remember_use devdsp
     check_include sys/soundcard.h
     use_devdsp="$have_sys_soundcard_h"
+    # this check is needed for FreeBSD but it only works when the C11 flags are used
+    C11_FLAGS="-D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L"
+    if [ "$have_sys_soundcard_h" = yes ]; then
+	if ! cc_check "checking if we need additional flags for sys/soundcard.h" "" "$C11_FLAGS" "no" "yes" <<EOF; then
+#include <sys/soundcard.h>
+int main(int argc, char **argv)
+{
+    #ifdef OPEN_SOUND_SYSTEM
+    return 0;
+    #else
+    return 1;
+    #endif
+}
+EOF
+
+            if cc_check "checking if we need __BSD_VISIBLE for sys/soundcard.h" "" "$C11_FLAGS -D__BSD_VISIBLE" "yes" "no" <<EOF; then
+#include <sys/soundcard.h>
+int main(int argc, char **argv)
+{
+    #ifdef OPEN_SOUND_SYSTEM
+    return 0;
+    #else
+    return 1;
+    #endif
+}
+EOF
+                append_nodupe CFLAGS "-D__BSD_VISIBLE"
+	    else
+		echo "no way found to make sys/soundcard.h work"
+	        use_devdsp=no
+	    fi
+	fi
+    fi
     recheck_use devdsp
 fi
 


### PR DESCRIPTION
Add a check to `configure` to automatically set the `__BSD_VISIBLE` flag that fixes issue #105.

Also fixes the environment variables in the FreeBSD CI build and reduces the build matrix to reduce GitHub Action resource usage.