### PR TITLE
add application name and currently playing file to audio streams

### DIFF
--- a/midifile.c
+++ b/midifile.c
@@ -163,11 +163,12 @@ void midi_pan(cycles_t cycles, int channel, int pan)
 	midi_write_event(cycles, event, sizeof(event));
 }
 
-long midi_open(enum plugout_endian *endian, long rate, long *buffer_bytes)
+long midi_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
 {
 	UNUSED(endian);
 	UNUSED(rate);
 	UNUSED(buffer_bytes);
+	UNUSED(filename);
 
 	return 0;
 }

--- a/midifile.c
+++ b/midifile.c
@@ -163,12 +163,12 @@ void midi_pan(cycles_t cycles, int channel, int pan)
 	midi_write_event(cycles, event, sizeof(event));
 }
 
-long midi_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
+long midi_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata)
 {
 	UNUSED(endian);
 	UNUSED(rate);
 	UNUSED(buffer_bytes);
-	UNUSED(filename);
+	UNUSED(metadata);
 
 	return 0;
 }

--- a/midifile.h
+++ b/midifile.h
@@ -24,7 +24,7 @@ extern void midi_note_on(cycles_t cycles, int channel, int new_note, int velocit
 extern void midi_note_off(cycles_t cycles, int channel);
 extern void midi_pan(cycles_t cycles, int channel, int pan);
 
-extern long midi_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename);
+extern long midi_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata);
 extern int  midi_skip(int subsong);
 extern void midi_close(void);
 

--- a/midifile.h
+++ b/midifile.h
@@ -24,7 +24,7 @@ extern void midi_note_on(cycles_t cycles, int channel, int new_note, int velocit
 extern void midi_note_off(cycles_t cycles, int channel);
 extern void midi_pan(cycles_t cycles, int channel, int pan);
 
-extern long midi_open(enum plugout_endian *endian, long rate, long *buffer_bytes);
+extern long midi_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename);
 extern int  midi_skip(int subsong);
 extern void midi_close(void);
 

--- a/player.c
+++ b/player.c
@@ -555,6 +555,7 @@ struct gbs *common_init(int argc, char **argv)
 	struct gbs *gbs;
 	uint8_t songs;
 	uint8_t initial_subsong;
+	struct plugout_metadata metadata;
 
 	i18n_init();
 
@@ -581,7 +582,10 @@ struct gbs *common_init(int argc, char **argv)
 	} else {
 		actual_endian = requested_endian;
 	}
-	if (sound_open(&actual_endian, rate, &buf.bytes, filename) != 0) {
+
+	metadata.player_name = myname;
+	metadata.filename = filename;
+	if (sound_open(&actual_endian, rate, &buf.bytes, metadata) != 0) {
 		fprintf(stderr, _("Could not open output plugin \"%s\"\n"),
 		        sound_name);
 		exit(1);

--- a/player.c
+++ b/player.c
@@ -573,12 +573,15 @@ struct gbs *common_init(int argc, char **argv)
 		usage(1);
 	}
 
+	/* options have been parsed, argv[0] is our filename */
+	filename = filename_only(argv[0]);
+
 	if (requested_endian == PLUGOUT_ENDIAN_AUTOSELECT) {
 		actual_endian = PLUGOUT_ENDIAN_NATIVE;
 	} else {
 		actual_endian = requested_endian;
 	}
-	if (sound_open(&actual_endian, rate, &buf.bytes) != 0) {
+	if (sound_open(&actual_endian, rate, &buf.bytes, filename) != 0) {
 		fprintf(stderr, _("Could not open output plugin \"%s\"\n"),
 		        sound_name);
 		exit(1);
@@ -590,9 +593,6 @@ struct gbs *common_init(int argc, char **argv)
 		exit(1);
 	}
 	buf.data = malloc(buf.bytes);
-
-	/* options have been parsed, argv[0] is our filename */
-	filename = filename_only(argv[0]);
 
 	if (argc >= 2) {
 		sscanf(argv[1], "%ld", &subsong_start);

--- a/plugout.h
+++ b/plugout.h
@@ -43,7 +43,7 @@ enum plugout_endian {
 #endif
 
 /* Initial open of plugout. */
-typedef long    (*plugout_open_fn )(enum plugout_endian *endian, long rate, long *buffer_bytes);
+typedef long    (*plugout_open_fn )(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename);
 /* Notification when next subsong is about to start. */
 typedef int     (*plugout_skip_fn )(int subsong);
 /* Notification the the player is paused/resumed. */

--- a/plugout.h
+++ b/plugout.h
@@ -42,8 +42,13 @@ enum plugout_endian {
 #define PLUGOUT_ENDIAN_NATIVE PLUGOUT_ENDIAN_BIG
 #endif
 
+struct plugout_metadata {
+	const char * player_name;
+	const char * filename;
+};
+
 /* Initial open of plugout. */
-typedef long    (*plugout_open_fn )(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename);
+typedef long    (*plugout_open_fn )(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata);
 /* Notification when next subsong is about to start. */
 typedef int     (*plugout_skip_fn )(int subsong);
 /* Notification the the player is paused/resumed. */

--- a/plugout_alsa.c
+++ b/plugout_alsa.c
@@ -28,7 +28,7 @@ snd_pcm_t *pcm_handle;
 #define SND_PCM_FORMAT_S16_NE SND_PCM_FORMAT_S16_BE
 #endif
 
-static long alsa_open(enum plugout_endian *endian, long rate, long *buffer_bytes)
+static long alsa_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
 {
 	const char *pcm_name = "default";
 	int fmt, err;
@@ -36,6 +36,8 @@ static long alsa_open(enum plugout_endian *endian, long rate, long *buffer_bytes
 	snd_pcm_hw_params_t *hwparams;
 	snd_pcm_uframes_t buffer_frames = *buffer_bytes / 4;
 	snd_pcm_uframes_t period_frames;
+
+	UNUSED(filename);
 
 	switch (*endian) {
 	case PLUGOUT_ENDIAN_BIG:    fmt = SND_PCM_FORMAT_S16_BE; break;

--- a/plugout_alsa.c
+++ b/plugout_alsa.c
@@ -28,7 +28,7 @@ snd_pcm_t *pcm_handle;
 #define SND_PCM_FORMAT_S16_NE SND_PCM_FORMAT_S16_BE
 #endif
 
-static long alsa_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
+static long alsa_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata)
 {
 	const char *pcm_name = "default";
 	int fmt, err;
@@ -37,7 +37,7 @@ static long alsa_open(enum plugout_endian *endian, long rate, long *buffer_bytes
 	snd_pcm_uframes_t buffer_frames = *buffer_bytes / 4;
 	snd_pcm_uframes_t period_frames;
 
-	UNUSED(filename);
+	UNUSED(metadata);
 
 	switch (*endian) {
 	case PLUGOUT_ENDIAN_BIG:    fmt = SND_PCM_FORMAT_S16_BE; break;

--- a/plugout_devdsp.c
+++ b/plugout_devdsp.c
@@ -24,10 +24,12 @@
 
 static int fd;
 
-static long devdsp_open(enum plugout_endian *endian, long rate, long *buffer_bytes)
+static long devdsp_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
 {
 	int c;
 	int flags;
+
+	UNUSED(filename);
 	
 	if ((fd = open("/dev/dsp", O_WRONLY|O_NONBLOCK)) == -1) {
 		fprintf(stderr, _("Could not open /dev/dsp: %s\n"), strerror(errno));

--- a/plugout_devdsp.c
+++ b/plugout_devdsp.c
@@ -24,12 +24,12 @@
 
 static int fd;
 
-static long devdsp_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
+static long devdsp_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata)
 {
 	int c;
 	int flags;
 
-	UNUSED(filename);
+	UNUSED(metadata);
 	
 	if ((fd = open("/dev/dsp", O_WRONLY|O_NONBLOCK)) == -1) {
 		fprintf(stderr, _("Could not open /dev/dsp: %s\n"), strerror(errno));

--- a/plugout_dsound.c
+++ b/plugout_dsound.c
@@ -30,9 +30,11 @@ static DWORD writeMax;       // Maximum amount we can write at once.
 static WAVEFORMATEX wfx;
 static DSBUFFERDESC dsbdesc;
 
-static long dsound_open(enum plugout_endian *endian, long rate, long *buffer_bytes)
+static long dsound_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
 {
 	HRESULT hr;
+	
+	UNUSED(filename);
 
 	*endian = PLUGOUT_ENDIAN_NATIVE;
 

--- a/plugout_iodumper.c
+++ b/plugout_iodumper.c
@@ -17,13 +17,20 @@
 static FILE *file;
 static cycles_t cycles_prev = 0;
 
-static long iodumper_open(enum plugout_endian *endian, long rate, long *buffer_bytes)
+static long iodumper_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
 {
+	int fd;
+
+	UNUSED(endian);
+	UNUSED(rate);
+	UNUSED(buffer_bytes);
+	UNUSED(filename);
+
 	/*
 	 * clone and close STDOUT_FILENO
 	 * to make sure nobody else can write to stdout
 	 */
-	int fd = dup(STDOUT_FILENO);
+	fd = dup(STDOUT_FILENO);
 	if (fd == -1) return -1;
 	(void)close(STDOUT_FILENO);
 	file = fdopen(fd, "w");

--- a/plugout_iodumper.c
+++ b/plugout_iodumper.c
@@ -17,14 +17,14 @@
 static FILE *file;
 static cycles_t cycles_prev = 0;
 
-static long iodumper_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
+static long iodumper_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata)
 {
 	int fd;
 
 	UNUSED(endian);
 	UNUSED(rate);
 	UNUSED(buffer_bytes);
-	UNUSED(filename);
+	UNUSED(metadata);
 
 	/*
 	 * clone and close STDOUT_FILENO

--- a/plugout_nas.c
+++ b/plugout_nas.c
@@ -35,7 +35,7 @@ static AuServer *nas_server;
 static AuFlowID             nas_flow;
 
 /* forward function declarations */
-static long    nas_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename);
+static long    nas_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata);
 static ssize_t nas_write(const void *buf, size_t count);
 static void    nas_close();
 
@@ -94,10 +94,10 @@ static AuDeviceID nas_find_device(AuServer *aud)
  * @param rate  requested samplerate
  * @param buffer_bytes  pointer to requested buffer_size,
  *                      value update to actual buffer_size.
- * @param filename  filename currently playing (basename only)
+ * @param metadata  player name and currently playing filename (basename only)
  * @return  0 on success
  */
-static long nas_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
+static long nas_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata)
 {
 	char *text = "";
 	unsigned char nas_format;
@@ -106,7 +106,7 @@ static long nas_open(enum plugout_endian *endian, long rate, long *buffer_bytes,
 	AuDeviceID nas_device;
 
 	UNUSED(buffer_bytes);
-	UNUSED(filename);
+	UNUSED(metadata);
 
 	switch (*endian) {
 	case PLUGOUT_ENDIAN_BIG:

--- a/plugout_nas.c
+++ b/plugout_nas.c
@@ -35,7 +35,7 @@ static AuServer *nas_server;
 static AuFlowID             nas_flow;
 
 /* forward function declarations */
-static long    nas_open(enum plugout_endian *endian, long rate, long *buffer_bytes);
+static long    nas_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename);
 static ssize_t nas_write(const void *buf, size_t count);
 static void    nas_close();
 
@@ -94,15 +94,19 @@ static AuDeviceID nas_find_device(AuServer *aud)
  * @param rate  requested samplerate
  * @param buffer_bytes  pointer to requested buffer_size,
  *                      value update to actual buffer_size.
+ * @param filename  filename currently playing (basename only)
  * @return  0 on success
  */
-static long nas_open(enum plugout_endian *endian, long rate, long *buffer_bytes)
+static long nas_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
 {
 	char *text = "";
 	unsigned char nas_format;
 	AuElement nas_elements[3];
 	AuStatus  status = AuBadValue;
 	AuDeviceID nas_device;
+
+	UNUSED(buffer_bytes);
+	UNUSED(filename);
 
 	switch (*endian) {
 	case PLUGOUT_ENDIAN_BIG:

--- a/plugout_pipewire.c
+++ b/plugout_pipewire.c
@@ -36,7 +36,7 @@ static const struct pw_stream_events pipewire_stream_events = {
         PW_VERSION_STREAM_EVENTS,
 };
 
-static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_bytes)
+static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
 {
 	const struct spa_pod *params[1];
 	uint8_t buffer[1024];
@@ -84,7 +84,7 @@ static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_b
 
 	// create stream
 	pipewire_data.stream = pw_stream_new_simple(pw_thread_loop_get_loop(pipewire_data.loop),
-						    "gbsplay",
+						    filename,
 						    props,
 						    &pipewire_stream_events,
 						    &pipewire_data);

--- a/plugout_pipewire.c
+++ b/plugout_pipewire.c
@@ -36,7 +36,7 @@ static const struct pw_stream_events pipewire_stream_events = {
         PW_VERSION_STREAM_EVENTS,
 };
 
-static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
+static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata)
 {
 	const struct spa_pod *params[1];
 	uint8_t buffer[1024];
@@ -64,7 +64,7 @@ static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_b
 	pw_init(0, NULL);
 
 	// set main loop
-	pipewire_data.loop = pw_thread_loop_new("gbsplay", NULL);
+	pipewire_data.loop = pw_thread_loop_new(metadata.player_name, NULL);
 
 	// set stream metadata
 	props = pw_properties_new(PW_KEY_MEDIA_TYPE, "Audio",
@@ -84,7 +84,7 @@ static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_b
 
 	// create stream
 	pipewire_data.stream = pw_stream_new_simple(pw_thread_loop_get_loop(pipewire_data.loop),
-						    filename,
+						    metadata.filename,
 						    props,
 						    &pipewire_stream_events,
 						    &pipewire_data);

--- a/plugout_pulse.c
+++ b/plugout_pulse.c
@@ -19,12 +19,14 @@
 #include "common.h"
 #include "plugout.h"
 
-pa_simple *pulse_handle;
-pa_sample_spec pulse_spec;
+static pa_simple *pulse_handle;
+static pa_sample_spec pulse_spec;
 
-static long pulse_open(enum plugout_endian *endian, long rate, long *buffer_bytes)
+static long pulse_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
 {
 	int err;
+
+	UNUSED(buffer_bytes);
 
 	switch (*endian) {
 	case PLUGOUT_ENDIAN_BIG:    pulse_spec.format = PA_SAMPLE_S16BE; break;
@@ -34,7 +36,7 @@ static long pulse_open(enum plugout_endian *endian, long rate, long *buffer_byte
 	pulse_spec.rate = rate;
 	pulse_spec.channels = 2;
 
-	pulse_handle = pa_simple_new(NULL, "gbsplay", PA_STREAM_PLAYBACK, NULL, "gbsplay", &pulse_spec, NULL, NULL, &err);
+	pulse_handle = pa_simple_new(NULL, "gbsplay", PA_STREAM_PLAYBACK, NULL, filename, &pulse_spec, NULL, NULL, &err);
 	if (!pulse_handle) {
 		fprintf(stderr, "pulse: %s\n", pa_strerror(err));
 		return -1;

--- a/plugout_pulse.c
+++ b/plugout_pulse.c
@@ -22,7 +22,7 @@
 static pa_simple *pulse_handle;
 static pa_sample_spec pulse_spec;
 
-static long pulse_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
+static long pulse_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata)
 {
 	int err;
 
@@ -36,7 +36,7 @@ static long pulse_open(enum plugout_endian *endian, long rate, long *buffer_byte
 	pulse_spec.rate = rate;
 	pulse_spec.channels = 2;
 
-	pulse_handle = pa_simple_new(NULL, "gbsplay", PA_STREAM_PLAYBACK, NULL, filename, &pulse_spec, NULL, NULL, &err);
+	pulse_handle = pa_simple_new(NULL, metadata.player_name, PA_STREAM_PLAYBACK, NULL, metadata.filename, &pulse_spec, NULL, NULL, &err);
 	if (!pulse_handle) {
 		fprintf(stderr, "pulse: %s\n", pa_strerror(err));
 		return -1;

--- a/plugout_sdl.c
+++ b/plugout_sdl.c
@@ -27,7 +27,7 @@
 int device;
 SDL_AudioSpec obtained;
 
-static long sdl_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
+static long sdl_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata)
 {
 	SDL_AudioSpec desired;
 
@@ -36,7 +36,8 @@ static long sdl_open(enum plugout_endian *endian, long rate, long *buffer_bytes,
 		return -1;
 	}
 
-	SDL_SetHint(SDL_HINT_AUDIO_DEVICE_STREAM_NAME, filename);
+	SDL_SetHint(SDL_HINT_APP_NAME, metadata.player_name);
+	SDL_SetHint(SDL_HINT_AUDIO_DEVICE_STREAM_NAME, metadata.filename);
 
 	SDL_zero(desired);
 	desired.freq = rate;

--- a/plugout_sdl.c
+++ b/plugout_sdl.c
@@ -3,12 +3,13 @@
  *
  * SDL2 sound output plugin
  *
- * 2020 (C) by Christian Garbs <mitch@cgarbs.de>
+ * 2020-2024 (C) by Christian Garbs <mitch@cgarbs.de>
  * Licensed under GNU GPL v1 or, at your option, any later version.
  */
 
 #include <time.h>
 #include <SDL.h>
+#include <SDL_hints.h>
 
 #include "common.h"
 #include "plugout.h"
@@ -26,13 +27,16 @@
 int device;
 SDL_AudioSpec obtained;
 
-static long sdl_open(enum plugout_endian *endian, long rate, long *buffer_bytes)
+static long sdl_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
 {
 	SDL_AudioSpec desired;
+
 	if (SDL_Init(SDL_INIT_AUDIO) != 0) {
 		fprintf(stderr, _("Could not init SDL: %s\n"), SDL_GetError());
 		return -1;
 	}
+
+	SDL_SetHint(SDL_HINT_AUDIO_DEVICE_STREAM_NAME, filename);
 
 	SDL_zero(desired);
 	desired.freq = rate;

--- a/plugout_stdout.c
+++ b/plugout_stdout.c
@@ -27,11 +27,13 @@ static int set_fd_to_binmode()
 }
 
 static long stdout_open(enum plugout_endian *endian,
-                        long rate, long *buffer_bytes)
+                        long rate, long *buffer_bytes,
+                        const char *const filename)
 {
 	UNUSED(endian);
 	UNUSED(rate);
 	UNUSED(buffer_bytes);
+	UNUSED(filename);
 
 	/*
 	 * clone and close STDOUT_FILENO

--- a/plugout_stdout.c
+++ b/plugout_stdout.c
@@ -28,12 +28,12 @@ static int set_fd_to_binmode()
 
 static long stdout_open(enum plugout_endian *endian,
                         long rate, long *buffer_bytes,
-                        const char *const filename)
+                        const struct plugout_metadata metadata)
 {
 	UNUSED(endian);
 	UNUSED(rate);
 	UNUSED(buffer_bytes);
-	UNUSED(filename);
+	UNUSED(metadata);
 
 	/*
 	 * clone and close STDOUT_FILENO

--- a/plugout_vgm.c
+++ b/plugout_vgm.c
@@ -59,7 +59,12 @@ static void vgm_finalize(void) {
 	fpackat(vgmfile, VGM_OFS_NUMSAMPLES, "<d", (uint32_t)samples_total);
 }
 
-static long vgm_open(enum plugout_endian *endian, long rate, long *buffer_bytes) {
+static long vgm_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
+{
+	UNUSED(endian);
+	UNUSED(rate);
+	UNUSED(buffer_bytes);
+	UNUSED(filename);
 	return 0;
 }
 

--- a/plugout_vgm.c
+++ b/plugout_vgm.c
@@ -59,12 +59,12 @@ static void vgm_finalize(void) {
 	fpackat(vgmfile, VGM_OFS_NUMSAMPLES, "<d", (uint32_t)samples_total);
 }
 
-static long vgm_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const char *const filename)
+static long vgm_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata)
 {
 	UNUSED(endian);
 	UNUSED(rate);
 	UNUSED(buffer_bytes);
-	UNUSED(filename);
+	UNUSED(metadata);
 	return 0;
 }
 

--- a/plugout_wav.c
+++ b/plugout_wav.c
@@ -69,8 +69,12 @@ static int wav_close_file() {
 }
 
 static long wav_open(enum plugout_endian *endian,
-		     const long rate, long *buffer_bytes)
+		     const long rate, long *buffer_bytes,
+		     const char *const filename)
 {
+	UNUSED(buffer_bytes);
+	UNUSED(filename);
+
 	sample_rate = rate;
 
 	*endian = PLUGOUT_ENDIAN_LITTLE;

--- a/plugout_wav.c
+++ b/plugout_wav.c
@@ -70,10 +70,10 @@ static int wav_close_file() {
 
 static long wav_open(enum plugout_endian *endian,
 		     const long rate, long *buffer_bytes,
-		     const char *const filename)
+		     const struct plugout_metadata metadata)
 {
 	UNUSED(buffer_bytes);
-	UNUSED(filename);
+	UNUSED(metadata);
 
 	sample_rate = rate;
 


### PR DESCRIPTION
Set audio metadata to make application name and currently playing file available to other applications, eg. let pavucontrol (PulseAudio mixer app) show this ( :eye: bottom row):
![image](https://github.com/mmitch/gbsplay/assets/391942/dd83e9be-8186-4be0-be7e-599af734e0e5)

I have implemented this for these audio backends:
* plugout_pipewire
* plugout_pulse
* plugout_sdl (metadata is passed through to the audio backend SDL is using; whether it is shown depends on the chosen backend. PipeWire and PulseAudio should both work)

This might be added to other plugouts, too, but I don't know of they support meta data.

Theoretically we could also use `plugout_skip_fn` to append the currently playing subsong, but I did not implement this because for both PipeWire and Pulseaudio we would have to update from their "simple" stream access methods to a full-blown client implementation to be able to switch stream metadata on the fly.  This would be quite a rewrite of both plugouts and I did not want to do that.

As the current filename now is available in the plugouts, we could use it in file writing operations (MIDI, VGM or WAV plugouts using `file_open()` from `filewriter.c) in the future.