### PR TITLE
remove branch from build status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # gbsplay - A Gameboy sound player
 
-[![Code coverage status](https://codecov.io/github/mmitch/gbsplay/coverage.svg?branch=master)](https://codecov.io/github/mmitch/gbsplay?branch=master)
-[![Linux Build status](https://github.com/mmitch/gbsplay/workflows/Linux%20Build/badge.svg?branch=master)](https://github.com/mmitch/gbsplay/actions?query=workflow%3A%22Linux+Build%22)
-[![FreeBSD Build status](https://github.com/mmitch/gbsplay/workflows/FreeBSD%20Build/badge.svg?branch=master)](https://github.com/mmitch/gbsplay/actions?query=workflow%3A%22FreeBSD+Build%22)
-[![macOS Build status](https://github.com/mmitch/gbsplay/workflows/macOS%20Build/badge.svg?branch=master)](https://github.com/mmitch/gbsplay/actions?query=workflow%3A%22macOS+Build%22)
-[![Windows Build status](https://github.com/mmitch/gbsplay/workflows/Windows%20Build/badge.svg?branch=master)](https://github.com/mmitch/gbsplay/actions?query=workflow%3A%22Windows+Build%22)
-[![CodeQL status](https://github.com/mmitch/gbsplay/workflows/CodeQL/badge.svg?branch=master)](https://github.com/mmitch/gbsplay/actions?query=workflow%3ACodeQL)
+[![Code coverage status](https://codecov.io/github/mmitch/gbsplay/coverage.svg)](https://codecov.io/github/mmitch/gbsplay?branch=master)
+[![Linux Build status](https://github.com/mmitch/gbsplay/workflows/Linux%20Build/badge.svg)](https://github.com/mmitch/gbsplay/actions?query=workflow%3A%22Linux+Build%22)
+[![FreeBSD Build status](https://github.com/mmitch/gbsplay/workflows/FreeBSD%20Build/badge.svg)](https://github.com/mmitch/gbsplay/actions?query=workflow%3A%22FreeBSD+Build%22)
+[![macOS Build status](https://github.com/mmitch/gbsplay/workflows/macOS%20Build/badge.svg)](https://github.com/mmitch/gbsplay/actions?query=workflow%3A%22macOS+Build%22)
+[![Windows Build status](https://github.com/mmitch/gbsplay/workflows/Windows%20Build/badge.svg)](https://github.com/mmitch/gbsplay/actions?query=workflow%3A%22Windows+Build%22)
+[![CodeQL status](https://github.com/mmitch/gbsplay/workflows/CodeQL/badge.svg)](https://github.com/mmitch/gbsplay/actions?query=workflow%3ACodeQL)
 
 This program emulates the sound hardware of the Nintendo Gameboy.  It
 is able to play the sounds from a Gameboy module dump (.GBS format, as


### PR DESCRIPTION
According to https://github.com/orgs/community/discussions/14980 freshly created badges don't get a status when the branch is set in the URL.

So remove the branch in order to make our FreeBSD Build status badge show a build status instead of just `no status`.

This fixes #113.