### PR TITLE
fix unknown version numbers

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -10,6 +10,13 @@ Bugfixes:
 - gbs core:
   - fix noise channel LSFR for more faithful drumtracks in most ROMs
 
+- gbsplay
+  - fix display of unknown version number (gbsplay -V)
+
+Enhancements:
+
+- build process
+  - display version number during configure
 
 2024/02/04  -  0.0.96
 ~~~~~~~~~~~~~~~~~~~~~

--- a/configure
+++ b/configure
@@ -648,6 +648,20 @@ if [ -n "$buildalias" ] && [ "$buildalias" != "$hostalias" ]; then
     build_test=no
 fi
 
+# determine version that is built
+
+if [ -f .git/HEAD ]; then
+    # from git if the build happens in a repository
+    VERSION=$(git describe --tags)
+elif [ "$VERSION" = unknown ]; then
+    # get a rough version number based on HISTORY file
+    VERSION="$(
+	grep -E '^[0-9]{4}/[0-9]{2}/[0-9]{2}  -  [0-9]+.[0-9]+.[0-9]+' HISTORY \
+	    | sed -n '1{s/^.*  -  //;s/ .*//;p}'
+	)ish"
+fi
+echo "configure gbsplay $VERSION"
+
 ## check for C compiler
 
 printf "checking for working compiler:  "
@@ -677,19 +691,6 @@ if [ $RESULT -eq 0 ]; then
     fi
 else
     die "error executing '$BUILDCC'"
-fi
-
-# determine version that is built
-
-if [ -f .git/HEAD ]; then
-    # from git if the build happens in a repository
-    VERSION=$(git describe --tags)
-elif [ "$VERSION" = unknown ]; then
-    # get a rough version number based on HISTORY file
-    VERSION="$(
-	grep -E '^[0-9]{4}/[0-9]{2}/[0-9]{2}  -  [0-9]+.[0-9]+.[0-9]+' HISTORY \
-	    | sed -n '1{s/^.*  -  //;s/ .*//;p}'
-	)ish"
 fi
 
 ## check for windows environment

--- a/configure
+++ b/configure
@@ -60,7 +60,7 @@ LANG=C
 export LANG
 
 ## set default version number to unknown
-# will be overwritten on git build or tar.gz export
+# will be overwritten on git build or tar.gz export using 'make dist'
 VERSION=unknown
 
 ##### begin of subroutines
@@ -679,10 +679,17 @@ else
     die "error executing '$BUILDCC'"
 fi
 
-# Check git timestamp
+# determine version that is built
 
 if [ -f .git/HEAD ]; then
+    # from git if the build happens in a repository
     VERSION=$(git describe --tags)
+elif [ "$VERSION" = unknown ]; then
+    # get a rough version number based on HISTORY file
+    VERSION="$(
+	grep -E '^[0-9]{4}/[0-9]{2}/[0-9]{2}  -  [0-9]+.[0-9]+.[0-9]+' HISTORY \
+	    | sed -n '1{s/^.*  -  //;s/ .*//;p}'
+	)ish"
 fi
 
 ## check for windows environment


### PR DESCRIPTION
This fixes unknown version numbers from builds based on GitHub tarballs and .ZIPs by guesstimating a version number based on the current `HISTORY` file (latest release plus x).

The current master has this problem (this will be fixed once this pull request is merged):
```
$ cd /tmp
$ wget -q https://github.com/mmitch/gbsplay/archive/refs/heads/master.zip && unzip master.zip >/dev/null
$ cd gbsplay-master && make >/dev/null 2>&1 && ./gbsplay -V
/tmp/gbsplay-master
gbsplay unknown
```

A .tar.gz from a release shows the same problem:
```
$ cd /tmp
$ wget -q https://github.com/mmitch/gbsplay/archive/refs/tags/0.0.96.tar.gz && tar -xzf 0.0.96.tar.gz
$ cd gbsplay-0.0.96 && make >/dev/null 2>&1 && ./gbsplay -V
/tmp/gbsplay-0.0.96
gbsplay unknown
```

Whereas the branch of this pull request is already fixed and tells us we're _exactly at or somewhat after version 0.0.96_:
```
$ cd /tmp
$ wget -q https://github.com/mmitch/gbsplay/archive/refs/heads/version-number.zip && unzip version-number.zip >/dev/null
$ cd gbsplay-version-number && make >/dev/null 2>&1 && ./gbsplay -V
/tmp/gbsplay-version-number
gbsplay 0.0.96ish
```

This pull request also makes `configure` show the version number in fhe first line of its output.

This fixes #118.