### PR TITLE
fix playback speed in generated MIDI files

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -9,6 +9,7 @@ Bugfixes:
 
 - gbs core:
   - fix noise channel LSFR for more faithful drumtracks in most ROMs
+  - fix generated MIDI files being ~3% too slow
 
 - gbsplay
   - fix display of unknown version number (gbsplay -V)
@@ -17,6 +18,7 @@ Enhancements:
 
 - build process
   - display version number during configure
+
 
 2024/02/04  -  0.0.96
 ~~~~~~~~~~~~~~~~~~~~~

--- a/HISTORY
+++ b/HISTORY
@@ -9,7 +9,7 @@ Bugfixes:
 
 - gbs core:
   - fix noise channel LSFR for more faithful drumtracks in most ROMs
-  - fix generated MIDI files being ~3% too slow
+  - fix generated MIDI files being ~1.5% too slow
 
 - gbsplay
   - fix display of unknown version number (gbsplay -V)

--- a/Makefile
+++ b/Makefile
@@ -523,7 +523,7 @@ test: gbsplay $(tests) test_gbs
 	fi
 	$(Q)rm gbsplay-1.vgm
 	$(Q)MD5=`LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH-} $(TEST_WRAPPER) ./gbsplay -c examples/gbsplayrc_sample -E l -o midi $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null; cat gbsplay-1.mid | (md5sum || md5 -r) | cut -f1 -d\ `; \
-	EXPECT="656c7e54fe25e643ea74b7f1545312ae"; \
+	EXPECT="e947da918a2027f8e50417eb3629f804"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "MIDI output ok"; \
 	else \
@@ -533,7 +533,7 @@ test: gbsplay $(tests) test_gbs
 		exit 1; \
 	fi
 	$(Q)MD5=`LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH-} $(TEST_WRAPPER) ./gbsplay -c examples/gbsplayrc_sample -E l -o altmidi $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null; cat gbsplay-1.mid | (md5sum || md5 -r) | cut -f1 -d\ `; \
-	EXPECT="8fcf6be8d6c8a1c7f659c60e1a96db18"; \
+	EXPECT="d53639bb64f8fb5be3b0b7cf92a23841"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "alternate MIDI output ok"; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -523,7 +523,7 @@ test: gbsplay $(tests) test_gbs
 	fi
 	$(Q)rm gbsplay-1.vgm
 	$(Q)MD5=`LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH-} $(TEST_WRAPPER) ./gbsplay -c examples/gbsplayrc_sample -E l -o midi $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null; cat gbsplay-1.mid | (md5sum || md5 -r) | cut -f1 -d\ `; \
-	EXPECT="e947da918a2027f8e50417eb3629f804"; \
+	EXPECT="196960b3048d50a748dcd0d26c9ea2de"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "MIDI output ok"; \
 	else \
@@ -533,7 +533,7 @@ test: gbsplay $(tests) test_gbs
 		exit 1; \
 	fi
 	$(Q)MD5=`LD_LIBRARY_PATH=.:$${LD_LIBRARY_PATH-} $(TEST_WRAPPER) ./gbsplay -c examples/gbsplayrc_sample -E l -o altmidi $(TESTOPTS) examples/nightmode.gbs 1 < /dev/null; cat gbsplay-1.mid | (md5sum || md5 -r) | cut -f1 -d\ `; \
-	EXPECT="d53639bb64f8fb5be3b0b7cf92a23841"; \
+	EXPECT="972105e5d0644d65cc557d2904117d13"; \
 	if [ "$$MD5" = "$$EXPECT" ]; then \
 		echo "alternate MIDI output ok"; \
 	else \


### PR DESCRIPTION
#110 showed that I had a bugfix lying around for over a year, that is not cool…

I have verified both the bug and the fix by

1. running `gbsplay -o wav -1` to create a WAV file that does not contain channel 1
2. running `gbsplay -o midi -2 -3 -4` to create a MIDI file that only contains channel 1
3. running `timidity -Ow -o midi.wav` to convert the MIDI file to a WAV (using the default piano sound, but that's sufficient)
4. running `gbsplay -o altmidi -2 -3 -4` to create another MIDI file that only contains channel 1
5.running `timidity -Ow -o altmidi.wav` to convert the second MIDI file to a WAV, too
6. import all three resulting WAV files in _audacity_ and play them back together (I had the MIDI tracks panned to all left/all right and ramped up their volume to actually hear anything)

Without this fix, the sound was getting out of sync quite quickly: While the MIDI parts were in sync to each other, they did not match the other 3 channels.

With the fix, everything was fine over the whole 2 minute duration of default gbsplay runtime.

----

Originally this was just a refactoring to put a proper name on the magic number `124` in the MIDI header.

Understanding the meaning of the value (TIME_DIVISION of 124 with a default TEMPO of 500_000 ms) pointed out a serious bug: 3906 ms of audio data were spread to 4032 ms in the MIDI file, resulting in all generated MIDI files playing ~3% slower than desired.

This has now been fixed by:

- Extract, name and describe the magic constants that are used for the timing information in the generated MIDI files.

- Calculate new values for TEMPO and TIME_DIVISION making the MIDI speed match the audio data exactly.

- Explicitely set the tempo at the start of the MIDI track because the new TEMPO differs from the default value of 500_000 ms.