### PR TITLE
fix pipewire playback on more modern systems

### DIFF
--- a/plugout_pipewire.c
+++ b/plugout_pipewire.c
@@ -84,13 +84,11 @@ static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_b
 						    &pipewire_data);
 
 	// connect the stream
-	// TODO: do we need the realtime flag?
         if ((err = pw_stream_connect(pipewire_data.stream,
 				     PW_DIRECTION_OUTPUT,
 				     PW_ID_ANY,
 				     PW_STREAM_FLAG_AUTOCONNECT |
-				     PW_STREAM_FLAG_MAP_BUFFERS |
-				     PW_STREAM_FLAG_RT_PROCESS,
+				     PW_STREAM_FLAG_MAP_BUFFERS,
 				     params, 1))) {
 		fprintf(stderr, _("pw_stream_connect failed: %s\n"), spa_strerror(err));
 		return -1;

--- a/plugout_pipewire.c
+++ b/plugout_pipewire.c
@@ -167,8 +167,6 @@ static ssize_t pipewire_write(const void *buf, size_t count)
 
 static void pipewire_close()
 {
-        pw_thread_loop_wait(pipewire_data.loop);
-        pw_thread_loop_unlock(pipewire_data.loop);
         pw_thread_loop_stop(pipewire_data.loop);
 	pw_stream_destroy(pipewire_data.stream);
         pw_thread_loop_destroy(pipewire_data.loop);

--- a/plugout_pipewire.c
+++ b/plugout_pipewire.c
@@ -32,7 +32,7 @@ static const struct pw_stream_events pipewire_stream_events = {
 
 static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_bytes, const struct plugout_metadata metadata)
 {
-	const struct spa_pod *params[1];
+	const struct spa_pod *params[2];
 	uint8_t buffer[1024];
 	struct pw_properties *props;
 	struct spa_pod_builder pod_builder = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
@@ -75,6 +75,10 @@ static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_b
 						       .format = fmt,
 						       .channels = CHANNELS,
 						       .rate = rate));
+	// triple-buffer audio
+	params[1] = spa_pod_builder_add_object(&pod_builder, SPA_TYPE_OBJECT_ParamBuffers,
+					       SPA_PARAM_Buffers,
+					       SPA_PARAM_BUFFERS_buffers, SPA_POD_Int(3));
 
 	// create stream
 	pipewire_data.stream = pw_stream_new_simple(pw_thread_loop_get_loop(pipewire_data.loop),
@@ -89,7 +93,7 @@ static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_b
 				     PW_ID_ANY,
 				     PW_STREAM_FLAG_AUTOCONNECT |
 				     PW_STREAM_FLAG_MAP_BUFFERS,
-				     params, 1))) {
+				     params, 2))) {
 		fprintf(stderr, _("pw_stream_connect failed: %s\n"), spa_strerror(err));
 		return -1;
 	}

--- a/plugout_pipewire.c
+++ b/plugout_pipewire.c
@@ -106,8 +106,10 @@ static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_b
 static void pipewire_pause(int pause)
 {
 	int err;
+	pw_thread_loop_lock(pipewire_data.loop);
 	if ((err = pw_stream_set_active(pipewire_data.stream, !pause)))
 		fprintf(stderr, _("pw_stream_set_active failed: %s\n"), spa_strerror(err));
+	pw_thread_loop_unlock(pipewire_data.loop);
 }
 
 static ssize_t pipewire_write(const void *buf, size_t count)

--- a/plugout_pipewire.c
+++ b/plugout_pipewire.c
@@ -1,7 +1,8 @@
 /*
  * gbsplay is a Gameboy sound player
  *
- * 2024 (C) by Christian Garbs <mitch@cgarbs.de>
+ * 2024-2025 (C) by Christian Garbs <mitch@cgarbs.de>
+ *                  Lisa Riedler <dev@riedler.wien>
  *
  * Licensed under GNU GPL v1 or, at your option, any later version.
  */

--- a/plugout_pipewire.c
+++ b/plugout_pipewire.c
@@ -95,7 +95,10 @@ static long pipewire_open(enum plugout_endian *endian, long rate, long *buffer_b
 	}
 
 	// run the loop
-	pw_thread_loop_start(pipewire_data.loop);
+	if ((err = pw_thread_loop_start(pipewire_data.loop) != 0)) {
+		fprintf(stderr, _("pw_thread_loop_start failed: %s\n"), spa_strerror(err));
+		return -1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
this should fix any issues with modern pw. I don't have any older versions to test compat, so I hope this didn't break anything in older versions.

fixes #131 