### PR TITLE
Small UI enhancements

### DIFF
--- a/gbsplay.c
+++ b/gbsplay.c
@@ -267,6 +267,7 @@ int main(int argc, char **argv)
 
 	/* clean up terminal */
 	restore_terminal();
+	/* unhide terminal cursor */
 	printf("\033[?25h");
 	if (verbosity>3) {
 		printf("\n\n\n\n\n\n");

--- a/gbsplay.c
+++ b/gbsplay.c
@@ -196,7 +196,7 @@ static void printstatus(struct gbs *gbs)
 
 	update_displaytime(&time, status);
 
-	printf("\r\033[A\033[A"
+	printf("\r\033[A\033[A\033[?25l"
 	       "Song %3d/%3d%s%s (%s)\033[K\n"
 	       "%02ld:%02ld/%02ld:%02ld",
 	       status->subsong+1, status->songs, pausemode ? " [Paused]" : "",
@@ -267,6 +267,7 @@ int main(int argc, char **argv)
 
 	/* clean up terminal */
 	restore_terminal();
+	printf("\033[?25h");
 	if (verbosity>3) {
 		printf("\n\n\n\n\n\n");
 	}

--- a/gbsplay.c
+++ b/gbsplay.c
@@ -265,10 +265,8 @@ int main(int argc, char **argv)
 	/* stop sound */
 	common_cleanup(gbs);
 
-	/* clean up terminal */
+	/* restore terminal state */
 	restore_terminal();
-	/* unhide terminal cursor */
-	printf("\033[?25h");
 	if (verbosity>3) {
 		printf("\n\n\n\n\n\n");
 	}

--- a/player.c
+++ b/player.c
@@ -47,7 +47,7 @@ enum playmode {
 	PLAYMODE_SHUFFLE = 3,
 };
 
-#define DEFAULT_REFRESH_DELAY 33
+#define DEFAULT_REFRESH_DELAY 17
 
 long refresh_delay = DEFAULT_REFRESH_DELAY; /* msec */
 

--- a/terminal_posix.c
+++ b/terminal_posix.c
@@ -71,6 +71,9 @@ void restore_terminal(void)
 {
 	if (terminit)
 		tcsetattr(STDIN_FILENO, TCSAFLUSH, &ots);
+
+	/* unhide cursor */
+	printf("\033[?25h");
 }
 
 long get_input(char *c)


### PR DESCRIPTION
Here I set the default refresh interval from 33 to 17 ms to closely match the ~60 Hz timing of probably most GameBoy games, so that the visualizer follows almost exactly what's going on.

I then also made it hide the cursor when playing, just to make it look a little cleaner especially on higher verbosity levels.