### PR TITLE
use secret token for CodeCov uploads

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -40,3 +40,5 @@ jobs:
       - name: Upload coverage to Codecov
         # upload to codecov.io
         uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Our CodeCov integration has been broken since the 0.0.96 release because CodeCov switched to token authorization by default, even for public projects like ours.

Pull requests from forks were still processed without a token, though.

Add a token to this repo to get this going again.