### PR TITLE
get rid of warning about `TEST_TARGETS` being undefined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,9 @@ endif
 
 # test built binary?
 ifeq ($(build_test),yes)
-TEST_TARGETS += test
+TEST_TARGETS = test
+else
+TEST_TARGETS =
 endif
 
 # Cygwin automatically adds .exe to binaries.


### PR DESCRIPTION
when the test suite is disabled that variable is left undefined so Make throws a warning on it,
this just sets it to be blank instead on such case